### PR TITLE
Fix BTC price tracker

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,19 @@
 function getBitcoinPrice() {
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function () {
-        if (this.readyState == 4 && this.status == 200) {
+        if (this.readyState === 4 && this.status === 200) {
             var response = JSON.parse(this.responseText);
-            var price = response.bpi.USD.rate;
-            document.getElementById("bitcoin-price").innerHTML = price + " USD";
+            // CoinGecko returns {"bitcoin":{"usd":12345}}
+            var price = response.bitcoin.usd;
+            // Round to the nearest whole dollar
+            document.getElementById("bitcoin-price").innerHTML = "$" + Math.round(price);
         }
     };
-    xhttp.open("GET", "https://api.coindesk.com/v1/bpi/currentprice.json", true);
+    xhttp.open(
+        "GET",
+        "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
+        true
+    );
     xhttp.send();
 }
 


### PR DESCRIPTION
## Summary
- use CoinGecko API for BTC price
- round to dollar amount

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861be6a99908326a0103e183f73f0a3