### PR TITLE
Fix alt text and navbar contrast

### DIFF
--- a/about.html
+++ b/about.html
@@ -23,7 +23,7 @@
 <p id="bitcoin-price"></p>
 
 <h1>About Bitcoin</h1>
-<img id="btcWhitePaper" src="bitcoinwhitepaper.png" alt="">
+<img id="btcWhitePaper" src="bitcoinwhitepaper.png" alt="Cover of the Bitcoin whitepaper">
 <a id="whitePaperLink" href="https://bitcoin.org/bitcoin.pdf">The Bitcoin Whitepaper</a>
 
 <p>Bitcoin is a digital currency that was created in 2009 by an unknown person or group of people using the pseudonym

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 nav {
     width: 100%;
-    background-color: #F7931A;
+    background-color: #B55100;
     position: fixed;
     top: 0;
     left: 0;
@@ -39,7 +39,7 @@ nav ul {
 
 nav li a {
     text-decoration: none;
-    color: black;
+    color: #ffffff;
     font-weight: bold;
     padding: 0.75rem 1rem;
     border-radius: 4px;
@@ -48,6 +48,7 @@ nav li a {
 
 nav li a:hover {
     background-color: #e0e0e0;
+    color: black;
 }
 
 #btc{

--- a/home.html
+++ b/home.html
@@ -30,7 +30,7 @@
         <h1 id="whatIsBitcoin">"Why Should I Care About Bitcoin?"</h1>
 
        
-        <img id="traits" src="bitcoingoldfiat.png" alt="Comparsion Table">
+        <img id="traits" src="bitcoingoldfiat.png" alt="Chart comparing Bitcoin, gold and fiat currency">
 
         <aside>Because Bitcoin has the best traits of money ever created.</aside>
 
@@ -114,7 +114,7 @@
 
         <p>So wtf does this have to do with Bitcoin? EVERYTHING.</p>
 
-        <h2 id="h2Bitcoin">Bitcoin, the Best Money</h2> <img id="btc" src="bitcoin.png" alt="Bitcoin">
+        <h2 id="h2Bitcoin">Bitcoin, the Best Money</h2> <img id="btc" src="bitcoin.png" alt="Bitcoin logo">
 
         <aside>Refer back to the traits of money chart. Look at the all the different traits Bitcoin is superior
             than gold and fiat at. 
@@ -145,7 +145,7 @@
                 </p>
 
             <h4>Scarce</h4>
-            <img id="waterBottle" src="waterbottleleak.png" alt="Water Bottle Leak">
+            <img id="waterBottle" src="waterbottleleak.png" alt="Illustration of a leaking water bottle representing inflation">
                 <p>The amount of Bitcoins that will ever exist is 21 million.
                 It won't change, it's a fixed amount, and we know the exact supply at all times.
                 This is a HUGE DEAL. </p>

--- a/howtobuy.html
+++ b/howtobuy.html
@@ -26,22 +26,22 @@
     If you have a friend who already owns some, you could use their referral link.</p>
 
 <figure class="referral">
-    <a href="https://exchange.gemini.com/register?referral=grx86dcx&type=referral"><img src="GeminiLogo.png" alt="Gemini Link"></a>
+    <a href="https://exchange.gemini.com/register?referral=grx86dcx&type=referral"><img src="GeminiLogo.png" alt="Gemini exchange logo"></a>
     <figcaption>When you buy $100, you get a bonus of $75 and so does the person that referred you</figcaption>
 </figure>
 
 <figure class="referral">
-    <a href="https://coinbase.com/join/DMNKB8B?src=referral-link"><img src="coinbase.png" alt="Coinbase Link"></a>
+    <a href="https://coinbase.com/join/DMNKB8B?src=referral-link"><img src="coinbase.png" alt="Coinbase logo"></a>
     <figcaption>$30 for you, $30 for who referred you after your first trade of $20 or more</figcaption>
 </figure>
 
 <figure class="referral">
-    <a href="https://beta.strike.me/handoff/referral/3EAB8I/"><img src="strike_logo_black.png" alt="Strike.me Link"></a>
+    <a href="https://beta.strike.me/handoff/referral/3EAB8I/"><img src="strike_logo_black.png" alt="Strike logo"></a>
     <figcaption>This referral link will give you $5 off when you deposit and will also give me $5!</figcaption>
 </figure>
 
 <figure class="referral">
-    <a href="https://cash.app/app/FQDLTHX"><img src="Cash_App-Full-Logo.png" alt="Cash App Link"></a>
+    <a href="https://cash.app/app/FQDLTHX"><img src="Cash_App-Full-Logo.png" alt="Cash App logo"></a>
     <figcaption>We each get $5 when you send $5 within 14 days of signing up</figcaption>
 </figure>
 


### PR DESCRIPTION
## Summary
- add descriptive alt text for all images
- darken navbar color and use white links
- tweak hover style for links

## Testing
- `python3 - <<'PY' ...` (contrast ratio)


------
https://chatgpt.com/codex/tasks/task_e_68632869ea548326892263709e176be2