### PR TITLE
Improve calculators styling and presets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -208,3 +208,25 @@ footer {
     border-top: 1px solid #ccc;
     color: #666;
 }
+
+/* Calculator styles */
+.calculators {
+    margin-top: 2rem;
+}
+
+.calculator-card {
+    background-color: #ffffff;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.calculator-card h2 {
+    margin-top: 0;
+    text-align: center;
+}
+
+.calculator-card button {
+    margin-top: 0.5rem;
+}

--- a/js/roi.js
+++ b/js/roi.js
@@ -85,14 +85,14 @@ function calculateCagr() {
     resultEl.innerHTML = output;
 }
 
-['growth-slow','growth-medium','growth-high'].forEach(id => {
+['growth-bear','growth-base','growth-bull'].forEach(id => {
     const el = document.getElementById(id);
     if (el) {
         el.addEventListener('click', () => {
             const rateInput = document.getElementById('cagr-rate');
-            if (id === 'growth-slow') rateInput.value = 5;
-            if (id === 'growth-medium') rateInput.value = 15;
-            if (id === 'growth-high') rateInput.value = 30;
+            if (id === 'growth-bear') rateInput.value = 16;
+            if (id === 'growth-base') rateInput.value = 24;
+            if (id === 'growth-bull') rateInput.value = 30;
             updateCagrDisplay();
         });
     }

--- a/whatif.html
+++ b/whatif.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>What If Calculator - The Satoshi Chronicles</title>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -18,46 +19,52 @@
             <li><a href="whatif.html">What If?</a></li>
         </ul>
     </nav>
-    <div class="container">
-        <h1>If I had bought Bitcoin...</h1>
-        <p><small>This calculator works for purchase dates within the last 365 days.</small></p>
-        <div>
-            <label for="investment">Amount in USD:</label>
-            <input type="number" id="investment" min="1" step="any">
+    <div class="container calculators">
+        <div class="calculator-card roi-calculator">
+            <h2>If I had bought Bitcoin...</h2>
+            <p><small>This calculator works for purchase dates within the last 365 days.</small></p>
+            <div>
+                <label for="investment">Amount in USD:</label>
+                <input type="number" id="investment" min="1" step="any">
+            </div>
+            <div>
+                <label for="purchase-date">Purchase date:</label>
+                <input type="date" id="purchase-date">
+            </div>
+            <button id="calc-btn">Calculate</button>
+            <p id="result"></p>
         </div>
-        <div>
-            <label for="purchase-date">Purchase date:</label>
-            <input type="date" id="purchase-date">
-        </div>
-        <button id="calc-btn">Calculate</button>
-        <p id="result"></p>
 
-        <h2>What if Bitcoin hits $1,000,000?</h2>
-        <p><small>Enter how much you invest today at the current price.</small></p>
-        <div>
-            <label for="invest-million">Amount in USD:</label>
-            <input type="number" id="invest-million" min="1" step="any">
+        <div class="calculator-card million-calculator">
+            <h2>What if Bitcoin hits $1,000,000?</h2>
+            <p><small>Enter how much you invest today at the current price.</small></p>
+            <div>
+                <label for="invest-million">Amount in USD:</label>
+                <input type="number" id="invest-million" min="1" step="any">
+            </div>
+            <button id="calc-million-btn">Calculate</button>
+            <p id="result-million"></p>
         </div>
-        <button id="calc-million-btn">Calculate</button>
-        <p id="result-million"></p>
 
-        <h2>Compounded annual growth projection</h2>
-        <div>
-            <label for="cagr-amount">Amount in USD you have today:</label>
-            <input type="number" id="cagr-amount" min="1" step="any">
+        <div class="calculator-card growth-calculator">
+            <h2>Compounded annual growth projection</h2>
+            <div>
+                <label for="cagr-amount">Amount in USD you have today:</label>
+                <input type="number" id="cagr-amount" min="1" step="any">
+            </div>
+            <div>
+                <label for="cagr-rate">Projected annual growth rate:</label>
+                <input type="range" id="cagr-rate" min="0" max="100" value="10">
+                <span id="cagr-rate-display">10%</span>
+            </div>
+            <div>
+                <button type="button" id="growth-bear">Bear Case (16%)</button>
+                <button type="button" id="growth-base">Base Case (24%)</button>
+                <button type="button" id="growth-bull">Bull Case (30%)</button>
+            </div>
+            <button id="cagr-calc-btn">Show Projection</button>
+            <p id="cagr-result"></p>
         </div>
-        <div>
-            <label for="cagr-rate">Projected annual growth rate:</label>
-            <input type="range" id="cagr-rate" min="0" max="100" value="10">
-            <span id="cagr-rate-display">10%</span>
-        </div>
-        <div>
-            <button type="button" id="growth-slow">Slow (5%)</button>
-            <button type="button" id="growth-medium">Medium (15%)</button>
-            <button type="button" id="growth-high">High (30%)</button>
-        </div>
-        <button id="cagr-calc-btn">Show Projection</button>
-        <p id="cagr-result"></p>
     </div>
     <script src="js/roi.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- include Google Fonts on calculators page
- give each calculator its own card section
- add CSS for card styling
- tweak CAGR preset buttons and JS logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6872e0419b4c8326b096b240768efe62