### PR TITLE
Enhance calculators with comma input and better button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -230,3 +230,19 @@ footer {
 .calculator-card button {
     margin-top: 0.5rem;
 }
+
+#cagr-calc-btn {
+    background-color: #4CAF50;
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+    box-shadow: 0 2px #388E3C;
+}
+
+#cagr-calc-btn:active {
+    box-shadow: none;
+    transform: translateY(2px);
+}

--- a/js/roi.js
+++ b/js/roi.js
@@ -3,8 +3,16 @@ function formatDate(inputDate) {
     return parts[2] + '-' + parts[1] + '-' + parts[0];
 }
 
+function parseNumber(value) {
+    return parseFloat(value.replace(/,/g, ''));
+}
+
+function formatCurrency(value) {
+    return Math.round(value).toLocaleString();
+}
+
 function calculateROI() {
-    const amount = parseFloat(document.getElementById('investment').value);
+    const amount = parseNumber(document.getElementById('investment').value);
     const date = document.getElementById('purchase-date').value;
     const resultEl = document.getElementById('result');
 
@@ -24,7 +32,7 @@ function calculateROI() {
                     const currentPrice = current.bitcoin.usd;
                     const btcAmount = amount / pastPrice;
                     const valueToday = btcAmount * currentPrice;
-                    resultEl.textContent = `Your $${amount.toFixed(2)} investment would be worth $${valueToday.toFixed(2)} today.`;
+                    resultEl.textContent = `Your $${formatCurrency(amount)} investment would be worth $${formatCurrency(valueToday)} today.`;
                 });
         })
         .catch(() => {
@@ -35,7 +43,7 @@ function calculateROI() {
 document.getElementById('calc-btn').addEventListener('click', calculateROI);
 
 function calculateMillion() {
-    const amount = parseFloat(document.getElementById('invest-million').value);
+    const amount = parseNumber(document.getElementById('invest-million').value);
     const resultEl = document.getElementById('result-million');
 
     if (!amount) {
@@ -49,7 +57,7 @@ function calculateMillion() {
             const currentPrice = data.bitcoin.usd;
             const btcAmount = amount / currentPrice;
             const futureValue = btcAmount * 1000000;
-            resultEl.textContent = `If Bitcoin reaches $1,000,000, your investment would be worth $${futureValue.toFixed(2)}.`;
+            resultEl.textContent = `If Bitcoin reaches $1,000,000, your investment would be worth $${formatCurrency(futureValue)}.`;
         })
         .catch(() => {
             resultEl.textContent = 'Unable to retrieve price data.';
@@ -67,7 +75,7 @@ function updateCagrDisplay() {
 }
 
 function calculateCagr() {
-    const amount = parseFloat(document.getElementById('cagr-amount').value);
+    const amount = parseNumber(document.getElementById('cagr-amount').value);
     const rate = parseFloat(document.getElementById('cagr-rate').value) / 100;
     const resultEl = document.getElementById('cagr-result');
 
@@ -80,7 +88,7 @@ function calculateCagr() {
     let output = '';
     years.forEach(y => {
         const value = amount * Math.pow(1 + rate, y);
-        output += `${y} year${y > 1 ? 's' : ''}: $${value.toFixed(2)}<br>`;
+        output += `${y} year${y > 1 ? 's' : ''}: $${formatCurrency(value)}<br>`;
     });
     resultEl.innerHTML = output;
 }

--- a/whatif.html
+++ b/whatif.html
@@ -25,7 +25,7 @@
             <p><small>This calculator works for purchase dates within the last 365 days.</small></p>
             <div>
                 <label for="investment">Amount in USD:</label>
-                <input type="number" id="investment" min="1" step="any">
+                <input type="text" id="investment" placeholder="e.g. 10,000">
             </div>
             <div>
                 <label for="purchase-date">Purchase date:</label>
@@ -40,7 +40,7 @@
             <p><small>Enter how much you invest today at the current price.</small></p>
             <div>
                 <label for="invest-million">Amount in USD:</label>
-                <input type="number" id="invest-million" min="1" step="any">
+                <input type="text" id="invest-million" placeholder="e.g. 1,000">
             </div>
             <button id="calc-million-btn">Calculate</button>
             <p id="result-million"></p>
@@ -50,7 +50,7 @@
             <h2>Compounded annual growth projection</h2>
             <div>
                 <label for="cagr-amount">Amount in USD you have today:</label>
-                <input type="number" id="cagr-amount" min="1" step="any">
+                <input type="text" id="cagr-amount" placeholder="e.g. 5,000">
             </div>
             <div>
                 <label for="cagr-rate">Projected annual growth rate:</label>


### PR DESCRIPTION
## Summary
- allow comma-separated input in calculators
- show numbers rounded to whole dollars with thousands separators
- update ROI, million and CAGR calculations to use new formatting
- tweak show projection button styling for visibility
- switch calculator inputs to text to accept commas

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6872e3ea39d08326ad4ed45c035060ec