### PR TITLE
Add chart to compounded growth projection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -299,3 +299,8 @@ footer {
     box-shadow: none;
     transform: translateY(2px);
 }
+
+.growth-calculator canvas {
+    width: 100%;
+    margin-top: 1rem;
+}

--- a/js/roi.js
+++ b/js/roi.js
@@ -74,6 +74,8 @@ function updateCagrDisplay() {
     }
 }
 
+let cagrChart;
+
 function calculateCagr() {
     const amount = parseNumber(document.getElementById('cagr-amount').value);
     const rate = parseFloat(document.getElementById('cagr-rate').value) / 100;
@@ -84,13 +86,47 @@ function calculateCagr() {
         return;
     }
 
-    const years = [1, 3, 5, 10, 20];
+    const displayYears = [1, 3, 5, 10, 20];
     let output = '';
-    years.forEach(y => {
+    displayYears.forEach(y => {
         const value = amount * Math.pow(1 + rate, y);
         output += `${y} year${y > 1 ? 's' : ''}: $${formatCurrency(value)}<br>`;
     });
     resultEl.innerHTML = output;
+
+    const chartYears = Array.from({ length: 21 }, (_, i) => i);
+    const chartValues = chartYears.map(y => amount * Math.pow(1 + rate, y));
+    const ctx = document.getElementById('cagr-chart').getContext('2d');
+    if (cagrChart) cagrChart.destroy();
+    cagrChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: chartYears,
+            datasets: [{
+                label: 'Projected value',
+                data: chartValues,
+                borderColor: 'rgba(75, 192, 192, 1)',
+                backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                fill: false
+            }]
+        },
+        options: {
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        label: ctx => `$${formatCurrency(ctx.parsed.y)}`
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    ticks: {
+                        callback: val => '$' + formatCurrency(val)
+                    }
+                }
+            }
+        }
+    });
 }
 
 ['growth-bear','growth-base','growth-bull'].forEach(id => {

--- a/whatif.html
+++ b/whatif.html
@@ -64,8 +64,10 @@
             </div>
             <button id="cagr-calc-btn">Show Projection</button>
             <p id="cagr-result"></p>
+            <canvas id="cagr-chart"></canvas>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="js/roi.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Display compounded annual growth projections on a new line chart using Chart.js
- Expose a canvas on the What If page to render the chart alongside CAGR results
- Style the canvas for full width within the growth calculator card

## Testing
- `node --check js/roi.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ace8f8a474832692189f1ceeb9b59a