### PR TITLE
Add navigation icons and dark, mockup-inspired color theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,12 +14,12 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav>
         <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html" aria-current="page">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+            <li><a href="home.html" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" aria-current="page" data-icon="👤">About</a></li>
+            <li><a href="blog.html" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
         </ul>
     </nav>
     <main id="main-content" class="container">
@@ -67,12 +67,12 @@
         <section class="page-directory" aria-label="Page directory">
             <h2>Explore the site</h2>
             <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html" aria-current="page">About</a></li>
-                <li><a href="blog.html">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
+                <li><a href="home.html" data-icon="🏠">Home</a></li>
+                <li><a href="about.html" aria-current="page" data-icon="👤">About</a></li>
+                <li><a href="blog.html" data-icon="📰">Blog</a></li>
+                <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+                <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+                <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
             </ul>
         </section>
     </main>

--- a/blog.html
+++ b/blog.html
@@ -14,12 +14,12 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav>
         <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html" aria-current="page">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+            <li><a href="home.html" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" data-icon="👤">About</a></li>
+            <li><a href="blog.html" aria-current="page" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
         </ul>
     </nav>
     <main id="main-content" class="container">
@@ -2028,12 +2028,12 @@
         <section class="page-directory" aria-label="Page directory">
             <h2>Explore the site</h2>
             <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html" aria-current="page">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
+                <li><a href="home.html" data-icon="🏠">Home</a></li>
+                <li><a href="about.html" data-icon="👤">About</a></li>
+                <li><a href="blog.html" aria-current="page" data-icon="📰">Blog</a></li>
+                <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+                <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+                <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
             </ul>
         </section>
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,13 +1,13 @@
 :root {
     --btc-orange: #f7931a;
-    --btc-orange-dark: #d97706;
-    --ink: #1f2933;
-    --ink-soft: #3e4c59;
-    --surface: #ffffff;
-    --surface-muted: #f7f8fa;
-    --surface-strong: #f1f5f9;
-    --border: rgba(0, 0, 0, 0.08);
-    --shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+    --btc-orange-dark: #ffb347;
+    --ink: #f5f7fb;
+    --ink-soft: #b9c7da;
+    --surface: #0a1624;
+    --surface-muted: #101f31;
+    --surface-strong: #15253a;
+    --border: rgba(185, 199, 218, 0.2);
+    --shadow: 0 14px 32px rgba(0, 0, 0, 0.45);
 }
 
 *,
@@ -18,12 +18,12 @@
 
 nav {
     width: 100%;
-    background: linear-gradient(90deg, var(--btc-orange), #ffb347);
+    background: linear-gradient(180deg, #0f1a2c 0%, #0a1321 100%);
     position: fixed;
     top: 0;
     left: 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.15);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+    border-bottom: 1px solid rgba(247, 147, 26, 0.35);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.55);
     z-index: 10;
 }
 
@@ -31,7 +31,7 @@ body {
     margin: 0;
     padding-top: 84px;
     font-family: 'Open Sans', Arial, sans-serif;
-    background: radial-gradient(circle at top, #fff8ef 0%, var(--surface-muted) 45%, #f1f5f9 100%);
+    background: radial-gradient(circle at top, #0e1a2c 0%, #07101b 45%, #050b14 100%);
     color: var(--ink);
     line-height: 1.7;
 }
@@ -91,28 +91,40 @@ nav ul {
 
 nav li a {
     text-decoration: none;
-    color: #ffffff;
+    color: #d9e3f2;
     font-weight: bold;
     padding: 0.6rem 0.95rem;
-    border-radius: 999px;
-    display: block;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.1rem;
     letter-spacing: 0.3px;
-    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+nav li a::before {
+    content: attr(data-icon);
+    font-size: 1rem;
+    color: var(--btc-orange);
+    line-height: 1;
 }
 
 nav li a:hover {
-    background-color: rgba(255, 255, 255, 0.85);
-    color: #111827;
+    background-color: rgba(247, 147, 26, 0.15);
+    color: #ffffff;
     transform: translateY(-1px);
+    box-shadow: inset 0 0 0 1px rgba(247, 147, 26, 0.5);
 }
 
 nav li a[aria-current="page"] {
-    background: #111827;
+    background: rgba(247, 147, 26, 0.2);
     color: #ffffff;
+    box-shadow: inset 0 -2px 0 0 var(--btc-orange);
 }
 
 .page-hero {
-    background: rgba(255, 255, 255, 0.92);
+    background: rgba(10, 22, 36, 0.95);
     border-radius: 24px;
     padding: 2rem;
     border: 1px solid var(--border);
@@ -129,7 +141,7 @@ nav li a[aria-current="page"] {
 }
 
 .content-panel {
-    background: #ffffff;
+    background: var(--surface);
     border-radius: 20px;
     padding: 1.75rem;
     box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
@@ -310,7 +322,7 @@ p {
     text-align: center;
     margin-bottom: 50px;
     padding: 1.5rem;
-    background-color: #ffffff;
+    background-color: var(--surface);
     border-radius: 10px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
@@ -331,7 +343,7 @@ p {
 }
 
 .resource-card {
-    background-color: #ffffff;
+    background-color: var(--surface);
     padding: 1.5rem;
     margin-bottom: 1.5rem;
     border-radius: 10px;
@@ -492,7 +504,7 @@ iframe {
 }
 
 .stat-card {
-    background: #ffffff;
+    background: var(--surface);
     padding: 1.25rem;
     border-radius: 16px;
     border: 1px solid rgba(15, 23, 42, 0.08);
@@ -507,7 +519,7 @@ iframe {
 
 .page-nav {
     margin: 2rem 0;
-    background: #ffffff;
+    background: var(--surface);
     padding: 1.5rem;
     border-radius: 20px;
     box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
@@ -540,7 +552,7 @@ iframe {
     gap: 1.5rem;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     align-items: center;
-    background: rgba(255, 255, 255, 0.7);
+    background: rgba(16, 31, 49, 0.85);
     border-radius: 20px;
     padding: 1.75rem;
     border: 1px solid rgba(15, 23, 42, 0.08);
@@ -555,7 +567,7 @@ iframe {
 }
 
 .intro-list li {
-    background: #ffffff;
+    background: var(--surface);
     padding: 0.85rem 1rem;
     border-radius: 12px;
     border: 1px solid rgba(15, 23, 42, 0.06);
@@ -571,7 +583,7 @@ iframe {
 }
 
 .faq details {
-    background: #ffffff;
+    background: var(--surface);
     padding: 1rem 1.25rem;
     border-radius: 14px;
     border: 1px solid rgba(15, 23, 42, 0.08);
@@ -595,7 +607,7 @@ iframe {
 }
 
 .audience-item {
-    background: #ffffff;
+    background: var(--surface);
     border-radius: 16px;
     border: 1px solid rgba(15, 23, 42, 0.1);
     box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
@@ -607,7 +619,7 @@ iframe {
     width: 100%;
     border: none;
     border-radius: 0;
-    background: #ffffff;
+    background: var(--surface);
     color: var(--ink);
     box-shadow: none;
     padding: 1rem 1.1rem;
@@ -675,7 +687,7 @@ iframe {
 }
 
 .concept-card {
-    background: #ffffff;
+    background: var(--surface);
     padding: 1.5rem;
     border-radius: 18px;
     border: 1px solid rgba(15, 23, 42, 0.08);
@@ -690,7 +702,7 @@ iframe {
 
 .learning-path {
     margin: 3rem 0;
-    background: #fffaf3;
+    background: #111d2e;
     border-radius: 20px;
     padding: 2rem;
     border: 1px solid rgba(247, 147, 26, 0.2);
@@ -705,7 +717,7 @@ iframe {
 }
 
 .timeline li {
-    background: #ffffff;
+    background: var(--surface);
     padding: 1.25rem;
     border-radius: 16px;
     border-left: 4px solid var(--btc-orange);
@@ -748,7 +760,7 @@ iframe {
 }
 
 .kit-card {
-    background: #ffffff;
+    background: var(--surface);
     padding: 1.5rem;
     border-radius: 18px;
     box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
@@ -777,7 +789,7 @@ iframe {
 
 .callout {
     margin-top: 2rem;
-    background: #ffffff;
+    background: var(--surface);
     padding: 1.5rem 1.75rem;
     border-radius: 18px;
     border-left: 6px solid var(--btc-orange);
@@ -811,7 +823,7 @@ iframe {
 
 .progress-tracker {
     margin-top: 2rem;
-    background: #ffffff;
+    background: var(--surface);
     padding: 1.75rem;
     border-radius: 18px;
     border: 1px solid rgba(15, 23, 42, 0.08);
@@ -891,7 +903,8 @@ textarea {
     border: 1px solid rgba(15, 23, 42, 0.16);
     font-size: 0.95rem;
     margin-top: 0.35rem;
-    background-color: #ffffff;
+    background-color: var(--surface-strong);
+    color: var(--ink);
 }
 
 label {
@@ -971,9 +984,9 @@ footer {
     padding: 1rem 0;
     font-size: 0.8rem;
     text-align: center;
-    background-color: #f2f2f2;
-    border-top: 1px solid #ccc;
-    color: #666;
+    background-color: #0a1321;
+    border-top: 1px solid var(--border);
+    color: var(--ink-soft);
 }
 
 /* Calculator styles */

--- a/explain-bitcoin-to-anyone.html
+++ b/explain-bitcoin-to-anyone.html
@@ -15,12 +15,12 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav>
         <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html" aria-current="page">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+            <li><a href="home.html" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" data-icon="👤">About</a></li>
+            <li><a href="blog.html" aria-current="page" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
         </ul>
     </nav>
 
@@ -53,12 +53,12 @@
         <section class="page-directory" aria-label="Page directory">
             <h2>Explore the site</h2>
             <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html" aria-current="page">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
+                <li><a href="home.html" data-icon="🏠">Home</a></li>
+                <li><a href="about.html" data-icon="👤">About</a></li>
+                <li><a href="blog.html" aria-current="page" data-icon="📰">Blog</a></li>
+                <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+                <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+                <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
             </ul>
         </section>
     </main>

--- a/home.html
+++ b/home.html
@@ -14,12 +14,12 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav>
         <ul>
-            <li><a href="home.html" aria-current="page">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+            <li><a href="home.html" aria-current="page" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" data-icon="👤">About</a></li>
+            <li><a href="blog.html" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
         </ul>
     </nav>
     <main id="main-content" class="container">
@@ -440,12 +440,12 @@
                 <section class="page-directory" aria-label="Page directory">
                     <h2>Explore the site</h2>
                     <ul class="page-links">
-                        <li><a href="home.html" aria-current="page">Home</a></li>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="blog.html">Blog</a></li>
-                        <li><a href="howtobuy.html">Buy</a></li>
-                        <li><a href="moreresources.html">Learn</a></li>
-                        <li><a href="whatif.html">Tools</a></li>
+                        <li><a href="home.html" aria-current="page" data-icon="🏠">Home</a></li>
+                        <li><a href="about.html" data-icon="👤">About</a></li>
+                        <li><a href="blog.html" data-icon="📰">Blog</a></li>
+                        <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+                        <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+                        <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
                     </ul>
                 </section>
     </main>

--- a/howtobuy.html
+++ b/howtobuy.html
@@ -12,12 +12,12 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav>
         <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html" aria-current="page">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+            <li><a href="home.html" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" data-icon="👤">About</a></li>
+            <li><a href="blog.html" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" aria-current="page" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
         </ul>
     </nav>
     <main id="main-content" class="container">
@@ -132,12 +132,12 @@
         <section class="page-directory" aria-label="Page directory">
             <h2>Explore the site</h2>
             <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html">Blog</a></li>
-                <li><a href="howtobuy.html" aria-current="page">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
+                <li><a href="home.html" data-icon="🏠">Home</a></li>
+                <li><a href="about.html" data-icon="👤">About</a></li>
+                <li><a href="blog.html" data-icon="📰">Blog</a></li>
+                <li><a href="howtobuy.html" aria-current="page" data-icon="🛒">Buy</a></li>
+                <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+                <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
             </ul>
         </section>
     </main>

--- a/moreresources.html
+++ b/moreresources.html
@@ -14,12 +14,12 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav>
         <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html" aria-current="page">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+            <li><a href="home.html" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" data-icon="👤">About</a></li>
+            <li><a href="blog.html" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" aria-current="page" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
         </ul>
 </nav>
     <main id="main-content" class="container">
@@ -96,12 +96,12 @@
     <section class="page-directory" aria-label="Page directory">
         <h2>Explore the site</h2>
         <ul class="page-links">
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html" aria-current="page">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+            <li><a href="home.html" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" data-icon="👤">About</a></li>
+            <li><a href="blog.html" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" aria-current="page" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" data-icon="🛠">Tools</a></li>
         </ul>
     </section>
 

--- a/whatif.html
+++ b/whatif.html
@@ -12,12 +12,12 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav>
         <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html" aria-current="page">Tools</a></li>
+            <li><a href="home.html" data-icon="🏠">Home</a></li>
+            <li><a href="about.html" data-icon="👤">About</a></li>
+            <li><a href="blog.html" data-icon="📰">Blog</a></li>
+            <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+            <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+            <li><a href="whatif.html" aria-current="page" data-icon="🛠">Tools</a></li>
         </ul>
     </nav>
     <main id="main-content" class="container calculators">
@@ -106,12 +106,12 @@
         <section class="page-directory" aria-label="Page directory">
             <h2>Explore the site</h2>
             <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html" aria-current="page">Tools</a></li>
+                <li><a href="home.html" data-icon="🏠">Home</a></li>
+                <li><a href="about.html" data-icon="👤">About</a></li>
+                <li><a href="blog.html" data-icon="📰">Blog</a></li>
+                <li><a href="howtobuy.html" data-icon="🛒">Buy</a></li>
+                <li><a href="moreresources.html" data-icon="📘">Learn</a></li>
+                <li><a href="whatif.html" aria-current="page" data-icon="🛠">Tools</a></li>
             </ul>
         </section>
     </main>


### PR DESCRIPTION
### Motivation
- Improve the header UI to match the provided mockup by adding small icons above each navigation label and switching the site to a darker color palette for stronger visual identity and contrast.
- Ensure all text and UI surfaces remain readable after the color change by adjusting font and control colors.

### Description
- Added `data-icon` attributes to the primary navigation links across site pages so each nav item (Home, About, Blog, Buy, Learn, Tools) can render a small icon above its label.
- Implemented `nav li a::before` to surface the icon and adjusted nav link layout to a columnar/icon-above-label style with updated hover and active states.
- Reworked root CSS variables and many component surface styles to a dark, mockup-inspired palette and increased contrast for text, inputs, and cards.
- Kept the change purely presentational with no JavaScript logic changes.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch issues, and it passed.
- Ran automated searches to verify `data-icon` attributes are present in the updated HTML files (verification scripts succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea92aab5e08326adc5c5a72af94434)