### PR TITLE
Add mobile-only dark homepage skeleton (mobile-first layout)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,15 @@
     --surface-strong: #f1f5f9;
     --border: rgba(0, 0, 0, 0.08);
     --shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+    --bg: #07090b;
+    --panel: #101418;
+    --panel-2: #151a20;
+    --text: #f5f1e8;
+    --muted: #a8a8a8;
+    --border-dark: rgba(255, 255, 255, 0.10);
+    --orange: #f7931a;
+    --orange-2: #ffad42;
+    --green: #3bd671;
 }
 
 *,
@@ -583,6 +592,10 @@ iframe {
     cursor: pointer;
 }
 
+.mobile-home-shell {
+    display: none;
+}
+
 /* Explain Bitcoin to Anyone page */
 .accordion-hint {
     margin-top: 0.9rem;
@@ -616,6 +629,387 @@ iframe {
     justify-content: space-between;
     font-size: 1rem;
     text-align: left;
+}
+
+@media (max-width: 768px) {
+    body {
+        padding-top: 0;
+        background: var(--bg);
+        color: var(--text);
+    }
+
+    .desktop-home-nav,
+    .desktop-home-main,
+    .desktop-home-footer {
+        display: none;
+    }
+
+    .mobile-home-shell {
+        display: block;
+        max-width: 430px;
+        margin: 0 auto;
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--text);
+        padding-bottom: 1rem;
+    }
+
+    .mobile-top-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.9rem 1rem;
+        background: #0b0f13;
+        border-bottom: 1px solid var(--border-dark);
+    }
+
+    .mobile-brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.7rem;
+        color: var(--text);
+        font-family: Georgia, 'Times New Roman', serif;
+        font-size: 1.15rem;
+        text-decoration: none;
+    }
+
+    .mobile-brand:hover,
+    .mobile-brand:focus-visible {
+        text-decoration: none;
+    }
+
+    .mobile-brand-icon {
+        width: 2.1rem;
+        height: 2.1rem;
+        border-radius: 999px;
+        display: grid;
+        place-items: center;
+        color: #fff;
+        font-weight: 700;
+        font-family: Georgia, 'Times New Roman', serif;
+        background: radial-gradient(circle at 30% 30%, var(--orange-2), var(--orange));
+    }
+
+    .mobile-brand-text {
+        max-width: 10.5rem;
+        line-height: 1.05;
+    }
+
+    .mobile-menu-btn {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 0.8rem;
+        border: 1px solid var(--border-dark);
+        background: var(--panel);
+        color: #f2f2f2;
+        font-size: 1.2rem;
+    }
+
+    .mobile-icon-nav {
+        display: grid;
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+        padding: 0.55rem 0.45rem 0;
+        border-bottom: 1px solid var(--border-dark);
+        background: #0d1116;
+    }
+
+    .mobile-nav-item {
+        display: grid;
+        justify-items: center;
+        gap: 0.22rem;
+        color: var(--muted);
+        font-size: 0.72rem;
+        text-decoration: none;
+        padding: 0.35rem 0.15rem 0.5rem;
+        border-bottom: 2px solid transparent;
+    }
+
+    .mobile-nav-icon {
+        font-size: 0.95rem;
+        line-height: 1;
+    }
+
+    .mobile-nav-item.is-active {
+        color: var(--orange);
+        border-bottom-color: var(--orange);
+    }
+
+    .mobile-home-main {
+        padding: 0.95rem 1rem 0;
+        display: grid;
+        gap: 0.9rem;
+    }
+
+    .mobile-hero-card,
+    .mobile-price-card,
+    .mobile-mini-stat,
+    .mobile-start-card,
+    .mobile-qa-card,
+    .mobile-why-card {
+        background: linear-gradient(180deg, #0f141a, #0d1217);
+        border: 1px solid var(--border-dark);
+        border-radius: 1rem;
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+    }
+
+    .mobile-hero-card {
+        padding: 1.05rem;
+        overflow: hidden;
+        position: relative;
+    }
+
+    .mobile-hero-title {
+        margin: 0;
+        font-family: Georgia, 'Times New Roman', serif;
+        font-size: clamp(2rem, 8vw, 2.25rem);
+        line-height: 1.05;
+        color: #fff;
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .mobile-title-accent {
+        color: var(--orange);
+    }
+
+    .mobile-hero-subheadline {
+        margin: 0.8rem 0 0;
+        color: #d3d3d3;
+        line-height: 1.48;
+        max-width: 19rem;
+    }
+
+    .mobile-hero-actions {
+        margin-top: 0.95rem;
+        display: grid;
+        gap: 0.55rem;
+        max-width: 13.5rem;
+    }
+
+    .mobile-btn {
+        border-radius: 999px;
+        padding: 0.62rem 0.95rem;
+        font-weight: 700;
+        text-decoration: none;
+        text-align: center;
+    }
+
+    .mobile-btn-primary {
+        background: var(--orange);
+        color: #141414;
+    }
+
+    .mobile-btn-outline {
+        background: transparent;
+        border: 1px solid var(--border-dark);
+        color: var(--text);
+    }
+
+    .mobile-hero-visual {
+        position: absolute;
+        right: -0.45rem;
+        bottom: -0.3rem;
+        width: 45%;
+        max-width: 11.25rem;
+        aspect-ratio: 1;
+        border-radius: 50%;
+        background: radial-gradient(circle at center, rgba(247, 147, 26, 0.52), rgba(247, 147, 26, 0.04) 67%);
+        display: grid;
+        place-items: center;
+        pointer-events: none;
+    }
+
+    .mobile-hero-visual img {
+        width: 90%;
+        border-radius: 999px;
+        box-shadow: none;
+    }
+
+    .mobile-stats-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.6rem;
+    }
+
+    .mobile-price-card {
+        grid-column: 1 / -1;
+        padding: 0.9rem;
+    }
+
+    .mobile-price-kicker {
+        margin: 0;
+        display: flex;
+        justify-content: space-between;
+        color: #e8e8e8;
+        font-size: 0.92rem;
+    }
+
+    .mobile-live {
+        color: var(--green);
+    }
+
+    .mobile-price-value {
+        margin: 0.45rem 0 0.35rem;
+        font-size: 1.85rem;
+        font-weight: 700;
+        color: #f8f8f8;
+    }
+
+    .mobile-price-change {
+        margin: 0;
+        color: var(--green);
+        font-weight: 600;
+        font-size: 0.95rem;
+    }
+
+    .mobile-mini-chart {
+        margin-top: 0.65rem;
+        height: 34px;
+        border-radius: 0.5rem;
+        background:
+            linear-gradient(130deg, transparent 0 17%, rgba(247, 147, 26, 0.92) 17% 21%, transparent 21% 36%, rgba(247, 147, 26, 0.88) 36% 44%, transparent 44% 60%, rgba(247, 147, 26, 0.93) 60% 66%, transparent 66% 82%, rgba(247, 147, 26, 0.96) 82% 88%, transparent 88% 100%),
+            rgba(255, 255, 255, 0.03);
+    }
+
+    .mobile-mini-stat {
+        padding: 0.9rem 0.8rem;
+        text-align: center;
+    }
+
+    .mobile-mini-stat h3 {
+        margin: 0;
+        font-size: 2rem;
+        line-height: 1;
+        font-family: Georgia, 'Times New Roman', serif;
+        color: var(--orange);
+    }
+
+    .mobile-mini-stat p {
+        margin: 0.55rem 0 0;
+        color: #dadada;
+        font-size: 0.9rem;
+        line-height: 1.35;
+    }
+
+    .mobile-start-card,
+    .mobile-qa-card,
+    .mobile-why-card {
+        padding: 0.95rem;
+    }
+
+    .mobile-section-label {
+        margin: 0;
+        color: var(--orange);
+        font-size: 0.86rem;
+        font-weight: 700;
+    }
+
+    .mobile-start-card h2,
+    .mobile-qa-card h2,
+    .mobile-why-card h2 {
+        margin: 0.35rem 0 0;
+        color: var(--text);
+        font-size: 1.55rem;
+        font-family: Georgia, 'Times New Roman', serif;
+    }
+
+    .mobile-start-card > p {
+        color: #d0d0d0;
+        margin: 0.55rem 0 0;
+        line-height: 1.45;
+    }
+
+    .mobile-feature-grid {
+        margin-top: 0.85rem;
+        display: grid;
+        gap: 0.6rem;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .mobile-feature-item {
+        background: var(--panel-2);
+        border: 1px solid var(--border-dark);
+        border-radius: 0.7rem;
+        padding: 0.62rem 0.5rem;
+        text-align: center;
+        font-size: 0.88rem;
+        color: #efefef;
+    }
+
+    .mobile-section-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 0.6rem;
+    }
+
+    .mobile-section-head a {
+        color: var(--orange-2);
+        font-size: 0.88rem;
+    }
+
+    .mobile-faq-row {
+        margin-top: 0.65rem;
+        display: block;
+        background: var(--panel-2);
+        color: var(--text);
+        border: 1px solid var(--border-dark);
+        border-radius: 0.7rem;
+        padding: 0.72rem 0.85rem;
+        text-decoration: none;
+    }
+
+    .mobile-faq-row::after {
+        content: "›";
+        float: right;
+        color: #d8d8d8;
+    }
+
+    .mobile-why-grid {
+        margin-top: 0.65rem;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.55rem;
+    }
+
+    .mobile-why-item {
+        border: 1px solid var(--border-dark);
+        border-radius: 0.75rem;
+        background: var(--panel-2);
+        padding: 0.62rem 0.5rem;
+    }
+
+    .mobile-why-item h3 {
+        margin: 0;
+        color: var(--text);
+        font-size: 0.96rem;
+        line-height: 1.2;
+    }
+
+    .mobile-why-item p {
+        margin: 0.45rem 0 0;
+        color: #cfcfcf;
+        font-size: 0.8rem;
+        line-height: 1.3;
+    }
+
+    .mobile-home-footer {
+        margin: 1rem 1rem 0;
+        border-top: 1px solid var(--border-dark);
+        padding-top: 0.7rem;
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        color: #d0d0d0;
+        font-size: 0.75rem;
+    }
+
+    .mobile-home-footer p {
+        margin: 0;
+        color: inherit;
+        line-height: 1.4;
+    }
 }
 
 .audience-trigger:hover {

--- a/home.html
+++ b/home.html
@@ -12,7 +12,126 @@
 </head>
 <body>
     <a class="skip-link" href="#main-content">Skip to content</a>
-    <nav>
+    <section class="mobile-home-shell" aria-label="Mobile homepage preview">
+        <header class="mobile-top-header">
+            <a class="mobile-brand" href="home.html" aria-label="The Satoshi Chronicles home">
+                <span class="mobile-brand-icon">₿</span>
+                <span class="mobile-brand-text">The Satoshi Chronicles</span>
+            </a>
+            <button class="mobile-menu-btn" aria-label="Open menu" type="button">
+                ☰
+            </button>
+        </header>
+
+        <nav class="mobile-icon-nav" aria-label="Primary mobile navigation">
+            <a href="home.html" class="mobile-nav-item is-active" aria-current="page">
+                <span class="mobile-nav-icon">⌂</span>
+                <span>Home</span>
+            </a>
+            <a href="about.html" class="mobile-nav-item">
+                <span class="mobile-nav-icon">◌</span>
+                <span>About</span>
+            </a>
+            <a href="blog.html" class="mobile-nav-item">
+                <span class="mobile-nav-icon">▤</span>
+                <span>Blog</span>
+            </a>
+            <a href="howtobuy.html" class="mobile-nav-item">
+                <span class="mobile-nav-icon">🛒</span>
+                <span>Buy</span>
+            </a>
+            <a href="moreresources.html" class="mobile-nav-item">
+                <span class="mobile-nav-icon">☰</span>
+                <span>Learn</span>
+            </a>
+            <a href="whatif.html" class="mobile-nav-item">
+                <span class="mobile-nav-icon">⚙</span>
+                <span>Tools</span>
+            </a>
+        </nav>
+
+        <main class="mobile-home-main">
+            <section class="mobile-hero-card">
+                <div class="mobile-hero-copy">
+                    <h1 class="mobile-hero-title">
+                        <span>Bitcoin,</span>
+                        <span class="mobile-title-accent">explained simply</span>
+                    </h1>
+                    <p class="mobile-hero-subheadline">A beginner-friendly map to understand what Bitcoin is, why it matters, and how to own it safely without getting overwhelmed.</p>
+                    <div class="mobile-hero-actions">
+                        <a class="mobile-btn mobile-btn-primary" href="#quick-takeaways">Start with the basics</a>
+                        <a class="mobile-btn mobile-btn-outline" href="howtobuy.html">Read the buying guide</a>
+                    </div>
+                </div>
+                <div class="mobile-hero-visual" aria-hidden="true">
+                    <img src="bitcoin.png" alt="" loading="lazy">
+                </div>
+            </section>
+
+            <section class="mobile-stats-grid" aria-label="Bitcoin stats">
+                <article class="mobile-price-card">
+                    <p class="mobile-price-kicker"><span>Current Bitcoin Price</span><span class="mobile-live">Live</span></p>
+                    <p class="mobile-price-value">$63,742.18</p>
+                    <p class="mobile-price-change">▲ 1.82% (24h)</p>
+                    <div class="mobile-mini-chart" aria-hidden="true"></div>
+                </article>
+                <article class="mobile-mini-stat">
+                    <h3>21M</h3>
+                    <p>Hard capped supply</p>
+                </article>
+                <article class="mobile-mini-stat">
+                    <h3>100M</h3>
+                    <p>Satoshis in 1 Bitcoin</p>
+                </article>
+            </section>
+
+            <section class="mobile-start-card">
+                <p class="mobile-section-label">Start here</p>
+                <h2>A calmer way to learn Bitcoin</h2>
+                <p>Step-by-step guides, plain English explanations, and practical tools to help you go from curious to confident.</p>
+                <div class="mobile-feature-grid">
+                    <div class="mobile-feature-item">Beginner friendly</div>
+                    <div class="mobile-feature-item">Safe &amp; practical</div>
+                    <div class="mobile-feature-item">Clear roadmap</div>
+                    <div class="mobile-feature-item">No hype, just facts</div>
+                </div>
+            </section>
+
+            <section class="mobile-qa-card" aria-labelledby="mobile-qa-title">
+                <div class="mobile-section-head">
+                    <h2 id="mobile-qa-title">Quick answers</h2>
+                    <a href="#quick-takeaways">View all FAQs →</a>
+                </div>
+                <a class="mobile-faq-row" href="#quick-takeaways">Do I need to buy a full Bitcoin?</a>
+                <a class="mobile-faq-row" href="#quick-takeaways">What is the safest first step?</a>
+            </section>
+
+            <section class="mobile-why-card" aria-labelledby="mobile-why-title">
+                <h2 id="mobile-why-title">Why Bitcoin matters</h2>
+                <div class="mobile-why-grid">
+                    <article class="mobile-why-item">
+                        <h3>Financial freedom</h3>
+                        <p>Take control of your money and your future.</p>
+                    </article>
+                    <article class="mobile-why-item">
+                        <h3>Sound money</h3>
+                        <p>Scarce, secure, and built to last.</p>
+                    </article>
+                    <article class="mobile-why-item">
+                        <h3>Global &amp; permissionless</h3>
+                        <p>Send and receive value anywhere, anytime.</p>
+                    </article>
+                </div>
+            </section>
+        </main>
+
+        <footer class="mobile-home-footer">
+            <p><span>₿</span> The Satoshi Chronicles</p>
+            <p>Learn. Understand. Own Bitcoin.</p>
+        </footer>
+    </section>
+
+    <nav class="desktop-home-nav">
         <ul>
             <li><a href="home.html" aria-current="page">Home</a></li>
             <li><a href="about.html">About</a></li>
@@ -22,7 +141,7 @@
             <li><a href="whatif.html">Tools</a></li>
         </ul>
     </nav>
-    <main id="main-content" class="container">
+    <main id="main-content" class="container desktop-home-main">
         <section class="hero">
             <div class="hero-text">
                 <p class="eyebrow">Bitcoin, explained simply</p>
@@ -450,7 +569,7 @@
                 </section>
     </main>
 
-    <footer>
+    <footer class="desktop-home-footer">
         <p>This site is for educational purposes only and does not constitute financial advice.</p>
     </footer>
         <script type="text/javascript" src="js/main.js"></script>


### PR DESCRIPTION
### Motivation
- Implement a first-pass mobile homepage structure that matches the requested premium dark Bitcoin app layout while preserving existing routes and desktop content. 
- Provide a compact, mobile-first skeleton to iterate on later without touching blog, tools, calculators, or other pages.

### Description
- Added a mobile-only homepage shell to `home.html` that includes the top header, icon navigation row (Home/About/Blog/Buy/Learn/Tools), hero with split white/orange headline and stacked CTAs, stats row (price + 21M + 100M), "Start here" card with feature items, Quick Answers card, "Why Bitcoin matters" cards, and a compact mobile footer. 
- The hero visual uses the existing `bitcoin.png` asset and falls back to a CSS-styled coin/gradient area, ensuring no broken images. 
- Preserved the original desktop layout by wrapping desktop sections with `desktop-home-*` classes and showing the new shell only under a mobile media query. 
- Updated `css/style.css` with dark theme variables and a scoped mobile `@media (max-width: 768px)` rule that implements the rounded panels, thin borders, subtle shadows, orange accents, compact spacing, and max-width ~430px styles.
- Files changed: `home.html` and `css/style.css`.

### Testing
- Parsed `home.html` with Python's `html.parser` to validate the markup and the parse completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0668736c8326ad345f19cad1ed3f)