### PR TITLE
Add global minimalist icon navigation row under header

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,13 +22,43 @@
                 </span>
             </a>
         </div>
-        <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html" aria-current="page">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+        <ul class="global-icon-nav">
+            <li>
+                <a href="home.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>
+                    <span class="nav-label">Home</span>
+                </a>
+            </li>
+            <li>
+                <a href="about.html" aria-current="page">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.25"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg></span>
+                    <span class="nav-label">About</span>
+                </a>
+            </li>
+            <li>
+                <a href="blog.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="1.8"/><path d="M8 9.5h8M8 13h8M8 16.5h5"/></svg></span>
+                    <span class="nav-label">Blog</span>
+                </a>
+            </li>
+            <li>
+                <a href="howtobuy.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 7h2l2.2 9.2h8.6l2-6.2H7.4"/><circle cx="10" cy="19" r="1.3"/><circle cx="17" cy="19" r="1.3"/></svg></span>
+                    <span class="nav-label">Buy</span>
+                </a>
+            </li>
+            <li>
+                <a href="moreresources.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.5h6.8a3 3 0 0 1 3 3v8h-6.8a3 3 0 0 0-3 3z"/><path d="M19.5 6.5h-6.8a3 3 0 0 0-3 3v8h6.8a3 3 0 0 1 3 3z"/></svg></span>
+                    <span class="nav-label">Learn</span>
+                </a>
+            </li>
+            <li>
+                <a href="whatif.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 4.5h4M9 12h6M8 19.5h8"/><circle cx="8" cy="4.5" r="1.5"/><circle cx="16" cy="12" r="1.5"/><circle cx="11" cy="19.5" r="1.5"/></svg></span>
+                    <span class="nav-label">Tools</span>
+                </a>
+            </li>
         </ul>
     </nav>
     <main id="main-content" class="container">

--- a/blog.html
+++ b/blog.html
@@ -22,13 +22,43 @@
                 </span>
             </a>
         </div>
-        <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html" aria-current="page">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+        <ul class="global-icon-nav">
+            <li>
+                <a href="home.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>
+                    <span class="nav-label">Home</span>
+                </a>
+            </li>
+            <li>
+                <a href="about.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.25"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg></span>
+                    <span class="nav-label">About</span>
+                </a>
+            </li>
+            <li>
+                <a href="blog.html" aria-current="page">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="1.8"/><path d="M8 9.5h8M8 13h8M8 16.5h5"/></svg></span>
+                    <span class="nav-label">Blog</span>
+                </a>
+            </li>
+            <li>
+                <a href="howtobuy.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 7h2l2.2 9.2h8.6l2-6.2H7.4"/><circle cx="10" cy="19" r="1.3"/><circle cx="17" cy="19" r="1.3"/></svg></span>
+                    <span class="nav-label">Buy</span>
+                </a>
+            </li>
+            <li>
+                <a href="moreresources.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.5h6.8a3 3 0 0 1 3 3v8h-6.8a3 3 0 0 0-3 3z"/><path d="M19.5 6.5h-6.8a3 3 0 0 0-3 3v8h6.8a3 3 0 0 1 3 3z"/></svg></span>
+                    <span class="nav-label">Learn</span>
+                </a>
+            </li>
+            <li>
+                <a href="whatif.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 4.5h4M9 12h6M8 19.5h8"/><circle cx="8" cy="4.5" r="1.5"/><circle cx="16" cy="12" r="1.5"/><circle cx="11" cy="19.5" r="1.5"/></svg></span>
+                    <span class="nav-label">Tools</span>
+                </a>
+            </li>
         </ul>
     </nav>
     <main id="main-content" class="container">

--- a/css/style.css
+++ b/css/style.css
@@ -29,7 +29,7 @@ nav {
 
 body {
     margin: 0;
-    padding-top: 126px;
+    padding-top: 164px;
     font-family: 'Open Sans', Arial, sans-serif;
     background: radial-gradient(circle at top, #fff8ef 0%, var(--surface-muted) 45%, #f1f5f9 100%);
     color: var(--ink);
@@ -119,47 +119,75 @@ img {
     margin: 0 auto;
 }
 
-nav ul {
-    list-style-type: none;
-    padding: 0.45rem 0.75rem;
+nav ul.global-icon-nav {
+    list-style: none;
     margin: 0;
-    display: flex;
-    justify-content: flex-start;
-    gap: 0.5rem;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    padding: 0.55rem 0.5rem 0.45rem;
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    background: #0b0f12;
 }
 
-nav li a {
+nav ul.global-icon-nav li {
+    min-width: 0;
+}
+
+nav ul.global-icon-nav li a {
     text-decoration: none;
-    color: rgba(245, 241, 232, 0.9);
-    font-weight: 600;
-    padding: 0.45rem 0.85rem;
-    border-radius: 999px;
-    display: block;
+    color: #b7bcc3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.28rem;
+    padding: 0.2rem 0.15rem 0.45rem;
     letter-spacing: 0.2px;
-    border: 1px solid transparent;
-    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
 }
 
-nav li a:hover {
-    background-color: rgba(255, 255, 255, 0.08);
-    color: #ffffff;
-    border-color: rgba(255, 255, 255, 0.16);
-    transform: none;
+nav ul.global-icon-nav li a:hover,
+nav ul.global-icon-nav li a:focus-visible {
+    color: #f5f1e8;
+    text-decoration: none;
 }
 
-nav li a[aria-current="page"] {
-    color: #ffffff;
-    border-color: rgba(247, 147, 26, 0.6);
-    background: rgba(247, 147, 26, 0.16);
+nav ul.global-icon-nav .nav-icon {
+    width: 20px;
+    height: 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+nav ul.global-icon-nav .nav-icon svg {
+    width: 20px;
+    height: 20px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+nav ul.global-icon-nav .nav-label {
+    font-size: 0.77rem;
+    font-weight: 600;
+    line-height: 1.1;
+    white-space: nowrap;
+}
+
+nav ul.global-icon-nav li a[aria-current="page"] {
+    color: var(--btc-orange);
+    border-bottom-color: var(--btc-orange);
 }
 
 
 @media (min-width: 768px) {
     body {
-        padding-top: 132px;
+        padding-top: 170px;
     }
 
     .nav-brand {
@@ -171,8 +199,18 @@ nav li a[aria-current="page"] {
         font-size: 2rem;
     }
 
-    nav ul {
-        justify-content: center;
+    nav ul.global-icon-nav {
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
+    }
+
+    nav ul.global-icon-nav li a {
+        gap: 0.32rem;
+        padding-bottom: 0.52rem;
+    }
+
+    nav ul.global-icon-nav .nav-label {
+        font-size: 0.82rem;
     }
 }
 
@@ -989,7 +1027,7 @@ button:hover {
 
 @media (max-width: 600px) {
     body {
-        padding-top: 120px;
+        padding-top: 152px;
     }
 
     .nav-brand {
@@ -1001,14 +1039,23 @@ button:hover {
         line-height: 0.9;
     }
 
-    nav ul {
-        gap: 0.25rem;
-        padding: 0.35rem 0.6rem;
+    nav ul.global-icon-nav {
+        padding: 0.5rem 0.3rem 0.38rem;
     }
 
-    nav li a {
-        padding: 0.36rem 0.6rem;
-        font-size: 0.78rem;
+    nav ul.global-icon-nav li a {
+        gap: 0.22rem;
+        padding: 0.18rem 0 0.4rem;
+    }
+
+    nav ul.global-icon-nav .nav-icon,
+    nav ul.global-icon-nav .nav-icon svg {
+        width: 18px;
+        height: 18px;
+    }
+
+    nav ul.global-icon-nav .nav-label {
+        font-size: 0.72rem;
     }
 
     #btc,

--- a/explain-bitcoin-to-anyone.html
+++ b/explain-bitcoin-to-anyone.html
@@ -23,13 +23,43 @@
                 </span>
             </a>
         </div>
-        <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html" aria-current="page">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+        <ul class="global-icon-nav">
+            <li>
+                <a href="home.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>
+                    <span class="nav-label">Home</span>
+                </a>
+            </li>
+            <li>
+                <a href="about.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.25"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg></span>
+                    <span class="nav-label">About</span>
+                </a>
+            </li>
+            <li>
+                <a href="blog.html" aria-current="page">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="1.8"/><path d="M8 9.5h8M8 13h8M8 16.5h5"/></svg></span>
+                    <span class="nav-label">Blog</span>
+                </a>
+            </li>
+            <li>
+                <a href="howtobuy.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 7h2l2.2 9.2h8.6l2-6.2H7.4"/><circle cx="10" cy="19" r="1.3"/><circle cx="17" cy="19" r="1.3"/></svg></span>
+                    <span class="nav-label">Buy</span>
+                </a>
+            </li>
+            <li>
+                <a href="moreresources.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.5h6.8a3 3 0 0 1 3 3v8h-6.8a3 3 0 0 0-3 3z"/><path d="M19.5 6.5h-6.8a3 3 0 0 0-3 3v8h6.8a3 3 0 0 1 3 3z"/></svg></span>
+                    <span class="nav-label">Learn</span>
+                </a>
+            </li>
+            <li>
+                <a href="whatif.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 4.5h4M9 12h6M8 19.5h8"/><circle cx="8" cy="4.5" r="1.5"/><circle cx="16" cy="12" r="1.5"/><circle cx="11" cy="19.5" r="1.5"/></svg></span>
+                    <span class="nav-label">Tools</span>
+                </a>
+            </li>
         </ul>
     </nav>
 

--- a/home.html
+++ b/home.html
@@ -22,13 +22,43 @@
                 </span>
             </a>
         </div>
-        <ul>
-            <li><a href="home.html" aria-current="page">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+        <ul class="global-icon-nav">
+            <li>
+                <a href="home.html" aria-current="page">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>
+                    <span class="nav-label">Home</span>
+                </a>
+            </li>
+            <li>
+                <a href="about.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.25"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg></span>
+                    <span class="nav-label">About</span>
+                </a>
+            </li>
+            <li>
+                <a href="blog.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="1.8"/><path d="M8 9.5h8M8 13h8M8 16.5h5"/></svg></span>
+                    <span class="nav-label">Blog</span>
+                </a>
+            </li>
+            <li>
+                <a href="howtobuy.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 7h2l2.2 9.2h8.6l2-6.2H7.4"/><circle cx="10" cy="19" r="1.3"/><circle cx="17" cy="19" r="1.3"/></svg></span>
+                    <span class="nav-label">Buy</span>
+                </a>
+            </li>
+            <li>
+                <a href="moreresources.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.5h6.8a3 3 0 0 1 3 3v8h-6.8a3 3 0 0 0-3 3z"/><path d="M19.5 6.5h-6.8a3 3 0 0 0-3 3v8h6.8a3 3 0 0 1 3 3z"/></svg></span>
+                    <span class="nav-label">Learn</span>
+                </a>
+            </li>
+            <li>
+                <a href="whatif.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 4.5h4M9 12h6M8 19.5h8"/><circle cx="8" cy="4.5" r="1.5"/><circle cx="16" cy="12" r="1.5"/><circle cx="11" cy="19.5" r="1.5"/></svg></span>
+                    <span class="nav-label">Tools</span>
+                </a>
+            </li>
         </ul>
     </nav>
     <main id="main-content" class="container">

--- a/howtobuy.html
+++ b/howtobuy.html
@@ -20,13 +20,43 @@
                 </span>
             </a>
         </div>
-        <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html" aria-current="page">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+        <ul class="global-icon-nav">
+            <li>
+                <a href="home.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>
+                    <span class="nav-label">Home</span>
+                </a>
+            </li>
+            <li>
+                <a href="about.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.25"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg></span>
+                    <span class="nav-label">About</span>
+                </a>
+            </li>
+            <li>
+                <a href="blog.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="1.8"/><path d="M8 9.5h8M8 13h8M8 16.5h5"/></svg></span>
+                    <span class="nav-label">Blog</span>
+                </a>
+            </li>
+            <li>
+                <a href="howtobuy.html" aria-current="page">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 7h2l2.2 9.2h8.6l2-6.2H7.4"/><circle cx="10" cy="19" r="1.3"/><circle cx="17" cy="19" r="1.3"/></svg></span>
+                    <span class="nav-label">Buy</span>
+                </a>
+            </li>
+            <li>
+                <a href="moreresources.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.5h6.8a3 3 0 0 1 3 3v8h-6.8a3 3 0 0 0-3 3z"/><path d="M19.5 6.5h-6.8a3 3 0 0 0-3 3v8h6.8a3 3 0 0 1 3 3z"/></svg></span>
+                    <span class="nav-label">Learn</span>
+                </a>
+            </li>
+            <li>
+                <a href="whatif.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 4.5h4M9 12h6M8 19.5h8"/><circle cx="8" cy="4.5" r="1.5"/><circle cx="16" cy="12" r="1.5"/><circle cx="11" cy="19.5" r="1.5"/></svg></span>
+                    <span class="nav-label">Tools</span>
+                </a>
+            </li>
         </ul>
     </nav>
     <main id="main-content" class="container">

--- a/moreresources.html
+++ b/moreresources.html
@@ -22,13 +22,43 @@
                 </span>
             </a>
         </div>
-        <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html" aria-current="page">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
+        <ul class="global-icon-nav">
+            <li>
+                <a href="home.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>
+                    <span class="nav-label">Home</span>
+                </a>
+            </li>
+            <li>
+                <a href="about.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.25"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg></span>
+                    <span class="nav-label">About</span>
+                </a>
+            </li>
+            <li>
+                <a href="blog.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="1.8"/><path d="M8 9.5h8M8 13h8M8 16.5h5"/></svg></span>
+                    <span class="nav-label">Blog</span>
+                </a>
+            </li>
+            <li>
+                <a href="howtobuy.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 7h2l2.2 9.2h8.6l2-6.2H7.4"/><circle cx="10" cy="19" r="1.3"/><circle cx="17" cy="19" r="1.3"/></svg></span>
+                    <span class="nav-label">Buy</span>
+                </a>
+            </li>
+            <li>
+                <a href="moreresources.html" aria-current="page">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.5h6.8a3 3 0 0 1 3 3v8h-6.8a3 3 0 0 0-3 3z"/><path d="M19.5 6.5h-6.8a3 3 0 0 0-3 3v8h6.8a3 3 0 0 1 3 3z"/></svg></span>
+                    <span class="nav-label">Learn</span>
+                </a>
+            </li>
+            <li>
+                <a href="whatif.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 4.5h4M9 12h6M8 19.5h8"/><circle cx="8" cy="4.5" r="1.5"/><circle cx="16" cy="12" r="1.5"/><circle cx="11" cy="19.5" r="1.5"/></svg></span>
+                    <span class="nav-label">Tools</span>
+                </a>
+            </li>
         </ul>
 </nav>
     <main id="main-content" class="container">

--- a/whatif.html
+++ b/whatif.html
@@ -20,13 +20,43 @@
                 </span>
             </a>
         </div>
-        <ul>
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html">Learn</a></li>
-            <li><a href="whatif.html" aria-current="page">Tools</a></li>
+        <ul class="global-icon-nav">
+            <li>
+                <a href="home.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>
+                    <span class="nav-label">Home</span>
+                </a>
+            </li>
+            <li>
+                <a href="about.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.25"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/></svg></span>
+                    <span class="nav-label">About</span>
+                </a>
+            </li>
+            <li>
+                <a href="blog.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="1.8"/><path d="M8 9.5h8M8 13h8M8 16.5h5"/></svg></span>
+                    <span class="nav-label">Blog</span>
+                </a>
+            </li>
+            <li>
+                <a href="howtobuy.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 7h2l2.2 9.2h8.6l2-6.2H7.4"/><circle cx="10" cy="19" r="1.3"/><circle cx="17" cy="19" r="1.3"/></svg></span>
+                    <span class="nav-label">Buy</span>
+                </a>
+            </li>
+            <li>
+                <a href="moreresources.html">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 6.5h6.8a3 3 0 0 1 3 3v8h-6.8a3 3 0 0 0-3 3z"/><path d="M19.5 6.5h-6.8a3 3 0 0 0-3 3v8h6.8a3 3 0 0 1 3 3z"/></svg></span>
+                    <span class="nav-label">Learn</span>
+                </a>
+            </li>
+            <li>
+                <a href="whatif.html" aria-current="page">
+                    <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 4.5h4M9 12h6M8 19.5h8"/><circle cx="8" cy="4.5" r="1.5"/><circle cx="16" cy="12" r="1.5"/><circle cx="11" cy="19.5" r="1.5"/></svg></span>
+                    <span class="nav-label">Tools</span>
+                </a>
+            </li>
         </ul>
     </nav>
     <main id="main-content" class="container calculators">


### PR DESCRIPTION
### Motivation
- Provide a compact, high-end mobile-style navigation strip immediately below the branded header that appears on every page and exposes the six primary routes (Home, About, Blog, Buy, Learn, Tools) with clear active-state feedback.
- Keep the change strictly localized to the shared header/nav area, preserve all existing links and page content, and match the dark premium Bitcoin theme specified.

### Description
- Replaced the existing top nav list on every page with a new `ul` using the class `global-icon-nav` that contains six inline SVG minimalist icons and labels for `Home`, `About`, `Blog`, `Buy`, `Learn`, and `Tools`, preserving existing routes and `aria-current="page"` for the active link.
- Added compact, responsive styling in `css/style.css` to render the dark background strip (`#0b0f12`), muted inactive icon/text (`#b7bcc3`), thin orange active color and underline (`var(--btc-orange)`), subtle borders, and spacing so six items stay evenly distributed on all widths.
- Adjusted fixed-header offsets by increasing `body` padding at base and breakpoints so page content remains positioned correctly beneath the fixed header plus the new nav row.
- Files changed: `home.html`, `about.html`, `blog.html`, `howtobuy.html`, `moreresources.html`, `whatif.html`, `explain-bitcoin-to-anyone.html`, and `css/style.css`.

### Testing
- Verified the new markup exists on all pages by searching for `"<ul class=\"global-icon-nav\""` across HTML files, and the check succeeded.
- Verified page-specific active states still use `aria-current="page"` on the correct links across pages using a grep search, and the check succeeded.
- Attempted to run visual tests via `npx playwright --version` to capture screenshots, but Playwright installation failed in this environment due to an npm registry permission error (HTTP 403), so visual screenshot capture could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd863eebc8326808826a984fe8b82)