### PR TITLE
Refactor homepage body into compact mobile dashboard layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1831,6 +1831,8 @@ footer {
 .homepage {
     max-width: 430px;
     padding: 0 0.95rem 2rem;
+    display: grid;
+    gap: 0.95rem;
 }
 
 .homepage .home-card,
@@ -1838,219 +1840,251 @@ footer {
 .homepage .cta-banner,
 .homepage .page-directory {
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.025));
-    border: 1px solid var(--border);
-    border-radius: 20px;
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 18px;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
     padding: 1rem;
-    margin: 0 0 1rem;
+    margin: 0;
 }
 
 .homepage .hero {
-    gap: 1rem;
-    padding: 1rem;
+    display: grid;
     grid-template-columns: 1fr;
+    gap: 0.8rem;
+    align-items: end;
+    position: relative;
+    overflow: hidden;
 }
 
 .homepage .hero h1 {
-    margin: 0.25rem 0 0.45rem;
-    line-height: 1.15;
+    margin: 0;
+    font-family: "Georgia", "Times New Roman", serif;
+    font-size: clamp(2.25rem, 9.8vw, 3rem);
+    line-height: 1.02;
+    letter-spacing: -0.02em;
+    text-align: left;
+}
+
+.homepage .hero-title-main {
+    color: #f7ede1;
+    display: block;
+}
+
+.homepage .hero-title-accent {
+    color: var(--orange-2);
+    display: block;
 }
 
 .homepage .lead {
     font-size: 0.98rem;
-    line-height: 1.5;
-}
-
-.homepage .hero-media {
-    gap: 0.75rem;
-}
-
-.homepage .hero-media img {
-    max-height: 170px;
-    object-fit: contain;
+    line-height: 1.45;
+    margin: 0.5rem 0 0;
+    color: #d7dde3;
 }
 
 .homepage .hero-actions {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.6rem;
+    gap: 0.55rem;
+    margin-top: 0.8rem;
 }
 
 .homepage .button {
     width: 100%;
-    border-radius: 14px;
-    padding: 0.75rem 1rem;
+    border-radius: 13px;
+    min-height: 48px;
+    padding: 0.72rem 0.95rem;
+    font-size: 0.98rem;
+    font-weight: 700;
 }
 
-.homepage .price-card {
-    margin-top: 0;
-    border-radius: 16px;
-    padding: 0.8rem 0.9rem;
-    font-size: 1rem;
-    box-shadow: none;
-    background: rgba(14, 19, 23, 0.88);
+.homepage .hero-meta {
+    margin-top: 0.65rem;
+    font-size: 0.78rem;
+    color: var(--muted);
+}
+
+.homepage .hero-visual {
+    position: absolute;
+    right: -42px;
+    bottom: -38px;
+    width: 170px;
+    height: 170px;
+    pointer-events: none;
+}
+
+.homepage .coin-glow {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 35%, rgba(255, 181, 68, 0.95), rgba(239, 136, 24, 0.4) 45%, rgba(239, 136, 24, 0.12) 62%, rgba(239, 136, 24, 0) 74%);
+    filter: drop-shadow(0 0 22px rgba(238, 146, 44, 0.45));
 }
 
 .homepage .home-dashboard {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.65rem;
+    gap: 0.7rem;
     padding: 0;
-    background: transparent;
+    background: none;
     border: none;
     box-shadow: none;
 }
 
 .homepage .mini-card {
-    padding: 0.8rem;
-    border-radius: 15px;
-    background: var(--panel-glass);
-    border: 1px solid var(--border);
-    box-shadow: 0 8px 14px rgba(0, 0, 0, 0.18);
+    padding: 0.82rem;
+    border-radius: 16px;
+    background: rgba(11, 16, 22, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
 }
 
-.homepage .mini-card h3 {
+.homepage .price-dashboard-card {
+    grid-column: 1 / -1;
+}
+
+.homepage .dashboard-label {
     margin: 0;
-    font-size: 1rem;
-}
-
-.homepage .mini-card p {
-    margin: 0.35rem 0 0;
-    font-size: 0.87rem;
-    color: var(--muted);
-    line-height: 1.4;
-}
-
-.homepage .mini-link-card {
-    text-decoration: none;
-}
-
-.homepage .page-nav .nav-grid,
-.homepage .confidence-grid,
-.homepage .why-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.6rem;
-    margin-top: 0.8rem;
-}
-
-.homepage .nav-card,
-.homepage .confidence-item {
-    background: rgba(14, 19, 23, 0.78);
-    border-radius: 14px;
-    border: 1px solid var(--border);
-    padding: 0.72rem;
-}
-
-.homepage .nav-card,
-.homepage .confidence-item p {
-    font-size: 0.87rem;
-}
-
-.homepage .confidence-item h3,
-.homepage .why-grid h3 {
-    margin: 0;
-    font-size: 0.95rem;
-}
-
-.homepage .faq {
-    padding-bottom: 0.55rem;
-}
-
-.homepage .faq-grid {
-    gap: 0.5rem;
-}
-
-.homepage .faq details {
-    background: rgba(14, 19, 23, 0.78);
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    padding: 0.8rem 0.9rem;
-    box-shadow: none;
-}
-
-.homepage .faq summary {
-    list-style: none;
+    font-size: 0.86rem;
+    color: #e7edf6;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.95rem;
 }
 
-.homepage .faq summary::after {
-    content: "›";
+.homepage .live-dot {
+    color: #39d179;
+    font-weight: 700;
+    font-size: 0.82rem;
+}
+
+.homepage .price-dashboard-card h2 {
+    margin: 0.45rem 0 0;
+    font-size: 1.85rem;
+    line-height: 1.05;
+}
+
+.homepage .dashboard-footnote {
+    margin: 0.35rem 0 0;
+    font-size: 0.82rem;
+    color: var(--muted);
+}
+
+.homepage .mini-stat-card h3 {
+    margin: 0;
+    font-family: "Georgia", "Times New Roman", serif;
     color: var(--orange-2);
-    font-size: 1.2rem;
+    font-size: 2rem;
 }
 
-.homepage .faq details[open] summary::after {
-    transform: rotate(90deg);
+.homepage .mini-stat-card p {
+    margin: 0.35rem 0 0;
+    font-size: 0.92rem;
+    color: #d2d9e0;
+}
+
+.homepage .section-kicker {
+    margin: 0;
+    font-size: 0.84rem;
+    color: var(--orange-2);
+    font-weight: 700;
+}
+
+.homepage .start-here-panel h2,
+.homepage .quick-answers-panel h2,
+.homepage .why-bitcoin h2,
+.homepage .home-links h2 {
+    margin: 0.32rem 0 0;
+    font-size: 1.75rem;
+    line-height: 1.2;
+    text-align: left;
+}
+
+.homepage .start-here-grid,
+.homepage .why-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.55rem;
+    margin-top: 0.8rem;
+}
+
+.homepage .compact-feature {
+    background: rgba(12, 17, 22, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 14px;
+    padding: 0.72rem;
+}
+
+.homepage .compact-feature h3,
+.homepage .why-grid h3 {
+    margin: 0;
+    font-size: 0.98rem;
+}
+
+.homepage .compact-feature p,
+.homepage .why-grid p {
+    margin: 0.28rem 0 0;
+    font-size: 0.88rem;
+    color: var(--muted);
+}
+
+.homepage .quick-answers-panel .section-title-row {
+    margin-bottom: 0.55rem;
 }
 
 .homepage .section-title-row {
     display: flex;
-    align-items: baseline;
     justify-content: space-between;
-    gap: 0.65rem;
-    margin-bottom: 0.7rem;
-}
-
-.homepage .section-title-row h2 {
-    margin: 0;
+    align-items: center;
+    gap: 0.6rem;
 }
 
 .homepage .section-title-row a {
-    font-size: 0.85rem;
+    font-size: 0.88rem;
     font-weight: 700;
+    white-space: nowrap;
 }
 
-.homepage .intro-panel {
-    grid-template-columns: 1fr;
-    gap: 0.85rem;
-}
-
-.homepage .intro-list {
-    gap: 0.55rem;
-}
-
-.homepage .intro-list li {
-    background: rgba(14, 19, 23, 0.78);
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    padding: 0.72rem;
-    font-size: 0.9rem;
-}
-
-.homepage .link-rows {
+.homepage .quick-answer-list {
     display: grid;
-    gap: 0.5rem;
+    gap: 0.45rem;
 }
 
+.homepage .faq-row,
 .homepage .link-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.75rem 0.85rem;
+    padding: 0.72rem 0.82rem;
     border-radius: 14px;
-    background: rgba(14, 19, 23, 0.78);
-    border: 1px solid var(--border);
+    background: rgba(11, 16, 22, 0.88);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     color: var(--text-soft);
-    font-weight: 600;
     text-decoration: none;
 }
 
+.homepage .faq-row {
+    font-size: 0.95rem;
+}
+
+.homepage .link-rows {
+    display: grid;
+    gap: 0.45rem;
+    margin-top: 0.55rem;
+}
+
 .homepage .home-longform {
-    padding: 1.1rem;
+    padding: 1rem;
 }
 
 .homepage .home-longform h2,
 .homepage .home-longform h4 {
-    margin-top: 1.25rem;
+    margin-top: 1.1rem;
 }
 
 .homepage p {
-    margin: 0.75rem 0;
-    line-height: 1.6;
+    line-height: 1.55;
 }
 
 .homepage .cta-banner .cta-actions {
@@ -2079,19 +2113,23 @@ footer {
         max-width: 960px;
     }
 
-    .homepage .hero {
-        grid-template-columns: 1.15fr 0.85fr;
-    }
-
     .homepage .hero-actions {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+        max-width: 480px;
     }
 
     .homepage .home-dashboard,
-    .homepage .page-nav .nav-grid,
-    .homepage .confidence-grid,
     .homepage .why-grid,
-    .homepage .page-links {
+    .homepage .page-links,
+    .homepage .start-here-grid {
         grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .homepage .start-here-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .homepage .price-dashboard-card {
+        grid-column: span 2;
     }
 }

--- a/home.html
+++ b/home.html
@@ -64,90 +64,86 @@
     <main id="main-content" class="container homepage">
         <section class="hero home-card">
             <div class="hero-text">
-                <p class="eyebrow">Bitcoin, explained simply</p>
-                <h1>The Satoshi Chronicles</h1>
+                <h1><span class="hero-title-main">Bitcoin,</span> <span class="hero-title-accent">explained simply</span></h1>
                 <p class="lead">A beginner-friendly map to understand what Bitcoin is, why it matters, and how to own it safely without getting overwhelmed.</p>
                 <div class="hero-actions">
                     <a class="button primary" href="#quick-takeaways">Start with the basics</a>
                     <a class="button ghost" href="howtobuy.html">Read the buying guide</a>
                 </div>
-                <div class="price-meta">Updated <span id="price-updated">--</span> · Price pulled from CoinGecko.</div>
+                <div class="hero-meta">Updated <span id="price-updated">--</span> · Price from CoinGecko</div>
             </div>
-            <div class="hero-media">
-                <img src="Infinity21Million.png" alt="Illustration of the 21 million bitcoin supply cap" loading="lazy">
-                <div id="currentBTCPrice" class="price-card">Current Bitcoin Price: <span id="bitcoin-price"></span></div>
+            <div class="hero-visual" aria-hidden="true">
+                <span class="coin-glow"></span>
             </div>
         </section>
 
         <section class="home-dashboard" aria-label="Bitcoin quick stats and shortcuts">
+            <article id="currentBTCPrice" class="mini-card price-dashboard-card">
+                <p class="dashboard-label">Current Bitcoin Price <span class="live-dot">Live</span></p>
+                <h2>$<span id="bitcoin-price"></span></h2>
+                <p class="dashboard-footnote">USD market price</p>
+            </article>
             <article class="mini-card mini-stat-card">
                 <h3>21M</h3>
-                <p>Hard capped supply.</p>
+                <p>Hard capped supply</p>
             </article>
             <article class="mini-card mini-stat-card">
                 <h3>100M</h3>
-                <p>Satoshis in 1 Bitcoin.</p>
+                <p>Satoshis in 1 Bitcoin</p>
             </article>
-            <a class="mini-card mini-link-card" href="#quick-takeaways">
-                <h3>60-second basics</h3>
-                <p>Start with the fast summary.</p>
-            </a>
-            <a class="mini-card mini-link-card" href="howtobuy.html">
-                <h3>Buying guide</h3>
-                <p>Learn how to buy safely.</p>
-            </a>
         </section>
 
-        <section class="page-nav home-card" aria-labelledby="start-here">
-            <h2 id="start-here">Start here</h2>
-            <p class="lead">This homepage is long, so here are the fastest ways to get what you need.</p>
-            <div class="nav-grid">
-                <a class="nav-card" href="#quick-takeaways">Get the 60-second version</a>
-                <a class="nav-card" href="#whatIsBitcoin">Why Bitcoin matters</a>
-                <a class="nav-card" href="#what-is-money">What money is</a>
-                <a class="nav-card" href="#h2Bitcoin">Why Bitcoin is different</a>
-                <a class="nav-card" href="#bitcoin-price-outlook">How price fits in</a>
-                <a class="nav-card" href="howtobuy.html">Ready to buy safely?</a>
+        <section class="start-here-panel home-card" aria-labelledby="start-here-title">
+            <p class="section-kicker">Start here</p>
+            <h2 id="start-here-title">A calmer way to learn Bitcoin</h2>
+            <p class="lead">Step-by-step guides, plain English explanations, and practical tools to help you go from curious to confident.</p>
+            <div class="start-here-grid">
+                <article class="compact-feature"><h3>Beginner friendly</h3></article>
+                <article class="compact-feature"><h3>Safe &amp; practical</h3></article>
+                <article class="compact-feature"><h3>Clear roadmap</h3></article>
+                <article class="compact-feature"><h3>No hype, just facts</h3></article>
             </div>
         </section>
 
-        <section class="confidence-strip home-card" aria-labelledby="confidence-strip-heading">
-            <div class="confidence-card">
-                <p class="eyebrow">Start with confidence</p>
-                <h2 id="confidence-strip-heading">A calmer way to learn Bitcoin</h2>
-                <p>This site is designed to help first-time readers move from curiosity to confidence without hype, jargon, or pressure to rush.</p>
+        <section class="quick-answers-panel home-card" aria-labelledby="quick-answers-title">
+            <div class="section-title-row">
+                <h2 id="quick-answers-title">Quick answers</h2>
+                <a href="#quick-takeaways">View all FAQs →</a>
             </div>
-            <div class="confidence-grid">
-                <article class="confidence-item">
-                    <h3>Beginner focused</h3>
-                    <p>Short explanations, plain language, and simple examples that make the big ideas easier to keep up with.</p>
+            <div class="quick-answer-list">
+                <a class="faq-row" href="#quick-takeaways">Do I need to buy a full Bitcoin?<span aria-hidden="true">›</span></a>
+                <a class="faq-row" href="#quick-takeaways">What is the safest first step?<span aria-hidden="true">›</span></a>
+            </div>
+        </section>
+
+        <section class="why-bitcoin home-card" aria-labelledby="why-bitcoin-heading">
+            <h2 id="why-bitcoin-heading">Why Bitcoin matters</h2>
+            <div class="why-grid">
+                <article class="mini-card">
+                    <h3>Financial freedom</h3>
+                    <p>Take control of your money and your future.</p>
                 </article>
-                <article class="confidence-item">
-                    <h3>Safety first</h3>
-                    <p>Learn the basics of wallets, seed phrases, and small test purchases before making bigger decisions.</p>
+                <article class="mini-card">
+                    <h3>Sound money</h3>
+                    <p>Scarce, secure, and built to last.</p>
                 </article>
-                <article class="confidence-item">
-                    <h3>Built to explore</h3>
-                    <p>Jump to the sections you care about most, then come back later for the deeper context when you are ready.</p>
+                <article class="mini-card">
+                    <h3>Global &amp; permissionless</h3>
+                    <p>Send and receive value anywhere, anytime.</p>
                 </article>
             </div>
         </section>
 
-        <section class="faq home-card">
-            <h2>Quick answers to common questions</h2>
-            <div class="faq-grid">
-                <details>
-                    <summary>Is Bitcoin too late to start learning about?</summary>
-                    <p>No. The learning curve is the opportunity. Start small, learn the basics, and build confidence over time.</p>
-                </details>
-                <details>
-                    <summary>Do I need to buy a full Bitcoin?</summary>
-                    <p>Not at all. Bitcoin is divisible into 100 million satoshis. You can buy just a few dollars worth.</p>
-                </details>
-                <details>
-                    <summary>What is the safest first step?</summary>
-                    <p>Set up a wallet, write down your seed phrase, and practice with a tiny test transaction.</p>
-                </details>
+        <section class="home-links home-card" aria-labelledby="home-links-heading">
+            <div class="section-title-row">
+                <h2 id="home-links-heading">Keep exploring</h2>
+                <a href="moreresources.html">View all</a>
+            </div>
+            <div class="link-rows">
+                <a class="link-row" href="blog.html"><span>Latest blog posts</span><span aria-hidden="true">→</span></a>
+                <a class="link-row" href="whatif.html"><span>What-if calculators &amp; tools</span><span aria-hidden="true">→</span></a>
+                <a class="link-row" href="explain-bitcoin-to-anyone.html"><span>Explain Bitcoin scripts</span><span aria-hidden="true">→</span></a>
+                <a class="link-row" href="moreresources.html"><span>More resources</span><span aria-hidden="true">→</span></a>
             </div>
         </section>
 
@@ -163,40 +159,6 @@
                 <li><strong>Self-custody matters:</strong> wallets and seed phrases are part of owning Bitcoin safely.</li>
                 <li><strong>This page is a guide, not a pitch:</strong> learn the tradeoffs before risking real money.</li>
             </ul>
-        </section>
-
-        <section class="why-bitcoin home-card" aria-labelledby="why-bitcoin-heading">
-            <div class="section-title-row">
-                <h2 id="why-bitcoin-heading">Why Bitcoin matters</h2>
-                <a href="#whatIsBitcoin">Read the deep dive</a>
-            </div>
-            <div class="why-grid">
-                <article class="mini-card">
-                    <h3>Scarcity wins</h3>
-                    <p>Finite money preserves value better over long timeframes.</p>
-                </article>
-                <article class="mini-card">
-                    <h3>Self custody</h3>
-                    <p>Your wallet and seed phrase put ownership in your hands.</p>
-                </article>
-                <article class="mini-card">
-                    <h3>Open access</h3>
-                    <p>Bitcoin can be used globally without permission.</p>
-                </article>
-            </div>
-        </section>
-
-        <section class="home-links home-card" aria-labelledby="home-links-heading">
-            <div class="section-title-row">
-                <h2 id="home-links-heading">Keep exploring</h2>
-                <a href="moreresources.html">View all</a>
-            </div>
-            <div class="link-rows">
-                <a class="link-row" href="blog.html"><span>Latest blog posts</span><span aria-hidden="true">→</span></a>
-                <a class="link-row" href="whatif.html"><span>What-if calculators & tools</span><span aria-hidden="true">→</span></a>
-                <a class="link-row" href="explain-bitcoin-to-anyone.html"><span>Explain Bitcoin scripts</span><span aria-hidden="true">→</span></a>
-                <a class="link-row" href="moreresources.html"><span>More resources</span><span aria-hidden="true">→</span></a>
-            </div>
         </section>
 
         <section class="home-longform home-card" aria-labelledby="whatIsBitcoin">


### PR DESCRIPTION
### Motivation
- The homepage body looked like a large vertical poster with a huge centered hero image and pill-like cards which reduced information density on mobile. 
- The intent is to convert the hero and body into a compact, left-aligned, premium dashboard-like layout that surfaces key stats above the fold. 
- Keep header, logo, icon nav, routes, blog posts, calculators, tools and menu functionality unchanged while reducing vertical space and bubble-like styling.

### Description
- Rewrote the homepage body markup in `home.html` (sections below the icon nav) to replace the oversized hero with a left-aligned editorial headline (`Bitcoin,` / `explained simply`), compact CTAs, and a small CSS coin glow accent instead of the large `Infinity21Million.png` image. 
- Moved price and supply highlights into compact dashboard cards directly beneath the hero: a price dashboard card plus `21M` and `100M` stat cards, and made these visible much earlier in the flow. 
- Added grouped card sections matching the mockup: `Start here` (compact feature tiles), `Quick answers` (two compact FAQ rows with a link to view all), and a streamlined `Why Bitcoin matters` card with three mini cards. 
- Updated `css/style.css` with denser spacing, reduced border radii (16–18px), smaller button sizing (approx. 48px height, 13px radius), serif headline styling and size, darker premium card backgrounds, tighter paddings (12–18px targets), and responsive grid adjustments to favor mobile density while keeping desktop usable.

### Testing
- Parsed `home.html` using Python's built-in `html.parser` (`html.parser`) to ensure the updated HTML is syntactically valid and the parser returned successfully. 
- Attempted a mobile screenshot via Playwright (`npx playwright screenshot --device='iPhone 13' ...`) but the environment blocked npm package download (403), so visual regression capture could not complete. 
- Attempted `xmllint --html --noout home.html` but `xmllint` is not installed in this environment, so that validation was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f003c7cda48326bfe2ac8af9fb2283)