### PR TITLE
Simplify homepage price card; remove 'Start here' and bottom 'Explore the site' sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -102,18 +102,6 @@
                 institution. This means that it is not subject to inflation or manipulation by outside forces. It is also
                 pseudonymous, meaning that users can transact without revealing their identities.</p>
         </section>
-
-        <section class="page-directory" aria-label="Page directory">
-            <h2>Explore the site</h2>
-            <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html" aria-current="page">About</a></li>
-                <li><a href="blog.html">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
-            </ul>
-        </section>
     </main>
 
     <footer>

--- a/blog.html
+++ b/blog.html
@@ -2064,18 +2064,6 @@
             <a class="blog-back" href="#top">Back to top</a>
         </section>
 
-        <section class="page-directory" aria-label="Page directory">
-            <h2>Explore the site</h2>
-            <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html" aria-current="page">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
-            </ul>
-        </section>
-
     </main>
     <footer>
         <p>This site is for educational purposes only and does not constitute financial advice.</p>

--- a/explain-bitcoin-to-anyone.html
+++ b/explain-bitcoin-to-anyone.html
@@ -88,18 +88,6 @@
                 </details>
             </div>
         </section>
-
-        <section class="page-directory" aria-label="Page directory">
-            <h2>Explore the site</h2>
-            <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html" aria-current="page">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
-            </ul>
-        </section>
     </main>
 
     <footer>

--- a/home.html
+++ b/home.html
@@ -70,7 +70,6 @@
                     <a class="button primary" href="#quick-takeaways">Start with the basics</a>
                     <a class="button ghost" href="howtobuy.html">Read the buying guide</a>
                 </div>
-                <div class="hero-meta">Updated <span id="price-updated">--</span> · Price from CoinGecko</div>
             </div>
             <div class="hero-visual" aria-hidden="true">
                 <span class="coin-glow"></span>
@@ -80,7 +79,8 @@
         <section class="home-dashboard" aria-label="Bitcoin quick stats and shortcuts">
             <article id="currentBTCPrice" class="mini-card price-dashboard-card">
                 <p class="dashboard-label">Current Bitcoin Price <span class="live-dot">Live</span></p>
-                <h2>$<span id="bitcoin-price"></span></h2>
+                <h2><span id="bitcoin-price"></span></h2>
+                <p class="dashboard-footnote">Updated <span id="price-updated">--</span> · Price from CoinGecko</p>
                 <p class="dashboard-footnote">USD market price</p>
             </article>
             <article class="mini-card mini-stat-card">
@@ -91,18 +91,6 @@
                 <h3>100M</h3>
                 <p>Satoshis in 1 Bitcoin</p>
             </article>
-        </section>
-
-        <section class="start-here-panel home-card" aria-labelledby="start-here-title">
-            <p class="section-kicker">Start here</p>
-            <h2 id="start-here-title">A calmer way to learn Bitcoin</h2>
-            <p class="lead">Step-by-step guides, plain English explanations, and practical tools to help you go from curious to confident.</p>
-            <div class="start-here-grid">
-                <article class="compact-feature"><h3>Beginner friendly</h3></article>
-                <article class="compact-feature"><h3>Safe &amp; practical</h3></article>
-                <article class="compact-feature"><h3>Clear roadmap</h3></article>
-                <article class="compact-feature"><h3>No hype, just facts</h3></article>
-            </div>
         </section>
 
         <section class="quick-answers-panel home-card" aria-labelledby="quick-answers-title">
@@ -483,17 +471,6 @@
                         <a class="button primary" href="howtobuy.html">Go to the buying guide</a>
                         <a class="button ghost" href="moreresources.html">Explore more resources</a>
                     </div>
-                </section>
-                <section class="page-directory home-card" aria-label="Page directory">
-                    <h2>Explore the site</h2>
-                    <ul class="page-links">
-                        <li><a href="home.html" aria-current="page">Home</a></li>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="blog.html">Blog</a></li>
-                        <li><a href="howtobuy.html">Buy</a></li>
-                        <li><a href="moreresources.html">Learn</a></li>
-                        <li><a href="whatif.html">Tools</a></li>
-                    </ul>
                 </section>
     </main>
 

--- a/howtobuy.html
+++ b/howtobuy.html
@@ -167,18 +167,6 @@
     actively trading and withdraw the rest to a more secure wallet, such as a hardware wallet. This helps to minimize
     the risks and ensure that the user has full control over their funds.</p>
         </section>
-
-        <section class="page-directory" aria-label="Page directory">
-            <h2>Explore the site</h2>
-            <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html">Blog</a></li>
-                <li><a href="howtobuy.html" aria-current="page">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html">Tools</a></li>
-            </ul>
-        </section>
     </main>
     <footer>
         <p>These referral links may provide bonuses to both you and the site owner. This information is not financial advice.</p>

--- a/moreresources.html
+++ b/moreresources.html
@@ -130,20 +130,6 @@
             </p>
     </section>
 
-
-
-    <section class="page-directory" aria-label="Page directory">
-        <h2>Explore the site</h2>
-        <ul class="page-links">
-            <li><a href="home.html">Home</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="blog.html">Blog</a></li>
-            <li><a href="howtobuy.html">Buy</a></li>
-            <li><a href="moreresources.html" aria-current="page">Learn</a></li>
-            <li><a href="whatif.html">Tools</a></li>
-        </ul>
-    </section>
-
    
     </main>
     <footer>

--- a/whatif.html
+++ b/whatif.html
@@ -141,18 +141,6 @@
                 <canvas id="cagr-chart"></canvas>
             </div>
         </div>
-
-        <section class="page-directory" aria-label="Page directory">
-            <h2>Explore the site</h2>
-            <ul class="page-links">
-                <li><a href="home.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="blog.html">Blog</a></li>
-                <li><a href="howtobuy.html">Buy</a></li>
-                <li><a href="moreresources.html">Learn</a></li>
-                <li><a href="whatif.html" aria-current="page">Tools</a></li>
-            </ul>
-        </section>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="js/roi.js"></script>


### PR DESCRIPTION
### Motivation
- Remove duplicated dollar sign in the live BTC price and place the "Updated … · Price from CoinGecko" notification directly under the price so the price card is the single source of truth.
- Simplify the homepage by removing the auxiliary "Start here" panel which duplicates other navigation content.
- Clean up repeated bottom-of-page "Explore the site" page-directory blocks that appear on multiple pages to reduce clutter.

### Description
- Removed the hardcoded `$` prefix from the homepage price heading in `home.html` so the JS-only price rendering produces a single `$` symbol (`<h2><span id="bitcoin-price"></span></h2>`). 
- Moved the "Updated <span id=\"price-updated\">--</span> · Price from CoinGecko" line from the hero area into the homepage price card as a dashboard footnote in `home.html`.
- Removed the entire `start-here-panel` section from `home.html`.
- Removed the `page-directory` ("Explore the site") sections from the following pages: `home.html`, `about.html`, `blog.html`, `howtobuy.html`, `moreresources.html`, `whatif.html`, and `explain-bitcoin-to-anyone.html`.

### Testing
- Ran a repo-wide search for the site-directory markers with `rg -n "Explore the site|page-directory" *.html` and received no matches, confirming the sections were removed (success). 
- Inspected `home.html` to confirm the hardcoded `$` was removed and the `price-updated` element now appears under the price (manual file verification via `nl`/`sed` output; success). 
- Reviewed `git diff --stat` to confirm only the intended files changed (success). 
- Attempted a visual screenshot with Playwright using `npx playwright screenshot`, but installation failed due to an external npm registry `403 Forbidden`, so the visual smoke test could not run (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02753d8a083269f7f8af19b1aecce)