### PR TITLE
Remove auto-generated blog excerpts above article images

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -121,18 +121,6 @@ function setupBlogDiscovery() {
             meta.textContent = meta.textContent + " · " + readMinutes + " min read";
         }
 
-        var header = card.querySelector(".blog-header");
-        var title = card.querySelector(".blog-title");
-        var firstParagraph = card.querySelector("p:not(.blog-meta):not(.blog-excerpt)");
-        if (header && title && firstParagraph && !header.querySelector(".blog-excerpt")) {
-            var excerpt = document.createElement("p");
-            excerpt.className = "blog-excerpt";
-            excerpt.textContent = firstParagraph.textContent.trim().slice(0, 180);
-            if (firstParagraph.textContent.trim().length > 180) {
-                excerpt.textContent += "…";
-            }
-            title.insertAdjacentElement("afterend", excerpt);
-        }
     });
 
     if (!filterButtons.length || !discoveryCards.length) {


### PR DESCRIPTION
### Motivation
- Prevent the same intro/caption text from appearing twice by removing the script that auto-inserted generated excerpts above article images. 

### Description
- Deleted the excerpt-insertion block in `js/main.js` that created a `.blog-excerpt` paragraph and inserted it after each `.blog-title`. 
- Left the existing read-time calculation and topic filtering logic in `js/main.js` untouched so discovery and metadata behavior remain unchanged. 

### Testing
- Verified the change with `git diff -- js/main.js` to confirm the excerpt injection block was removed. 
- Committed the change successfully with `git commit` to record the modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe55ca906c8326b1e89df4b0bf1d8d)