### PR TITLE
Add icon links to homepage hamburger menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,7 +22,12 @@
                 </span>
             </a>
         </div>
-        <ul class="global-icon-nav">
+        <button class="nav-menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Open navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="global-icon-nav">
             <li>
                 <a href="home.html">
                     <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>

--- a/blog.html
+++ b/blog.html
@@ -22,7 +22,12 @@
                 </span>
             </a>
         </div>
-        <ul class="global-icon-nav">
+        <button class="nav-menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Open navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="global-icon-nav">
             <li>
                 <a href="home.html">
                     <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>

--- a/css/style.css
+++ b/css/style.css
@@ -60,6 +60,10 @@ body {
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.nav-menu-toggle {
+    display: none;
+}
+
 .brand-link {
     display: inline-flex;
     align-items: center;
@@ -2186,23 +2190,101 @@ body:has(.homepage) .brand-text span {
     display: inline;
 }
 
-body:has(.homepage) .global-icon-nav {
+body:has(.homepage) .nav-menu-toggle {
     position: absolute;
     top: 0.82rem;
     right: 0.95rem;
-    display: block;
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: space-between;
     width: 29px;
     height: 23px;
     padding: 0;
-    overflow: hidden;
     border: 0;
-    background: linear-gradient(#d8d8d8 0 0) top/100% 2px no-repeat,
-        linear-gradient(#d8d8d8 0 0) center/100% 2px no-repeat,
-        linear-gradient(#d8d8d8 0 0) bottom/100% 2px no-repeat;
+    border-radius: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    z-index: 12;
+}
+
+body:has(.homepage) .nav-menu-toggle:hover,
+body:has(.homepage) .nav-menu-toggle:focus-visible {
+    transform: none;
+    box-shadow: none;
+}
+
+body:has(.homepage) .nav-menu-toggle span {
+    display: block;
+    width: 100%;
+    height: 2px;
+    border-radius: 999px;
+    background: #d8d8d8;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+body:has(.homepage).nav-open .nav-menu-toggle span:nth-child(1) {
+    transform: translateY(10.5px) rotate(45deg);
+}
+
+body:has(.homepage).nav-open .nav-menu-toggle span:nth-child(2) {
+    opacity: 0;
+}
+
+body:has(.homepage).nav-open .nav-menu-toggle span:nth-child(3) {
+    transform: translateY(-10.5px) rotate(-45deg);
+}
+
+body:has(.homepage) .global-icon-nav {
+    position: absolute;
+    top: calc(100% + 0.45rem);
+    right: 0.85rem;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(88px, 1fr));
+    gap: 0.4rem;
+    width: min(92vw, 285px);
+    padding: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 18px;
+    background: rgba(11, 15, 18, 0.98);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.48);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+body:has(.homepage).nav-open .global-icon-nav {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
 }
 
 body:has(.homepage) .global-icon-nav li {
-    display: none;
+    display: block;
+}
+
+body:has(.homepage) .global-icon-nav li a {
+    min-height: 74px;
+    padding: 0.65rem 0.35rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.035);
+}
+
+body:has(.homepage) .global-icon-nav li a[aria-current="page"] {
+    border-color: rgba(247, 147, 26, 0.7);
+    background: rgba(247, 147, 26, 0.11);
+}
+
+body:has(.homepage) .global-icon-nav .nav-icon,
+body:has(.homepage) .global-icon-nav .nav-icon svg {
+    width: 23px;
+    height: 23px;
+}
+
+body:has(.homepage) .global-icon-nav .nav-label {
+    font-size: 0.86rem;
 }
 
 .homepage {

--- a/explain-bitcoin-to-anyone.html
+++ b/explain-bitcoin-to-anyone.html
@@ -23,7 +23,12 @@
                 </span>
             </a>
         </div>
-        <ul class="global-icon-nav">
+        <button class="nav-menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Open navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="global-icon-nav">
             <li>
                 <a href="home.html">
                     <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>

--- a/home.html
+++ b/home.html
@@ -22,7 +22,12 @@
                 </span>
             </a>
         </div>
-        <ul class="global-icon-nav">
+        <button class="nav-menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Open navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="global-icon-nav">
             <li>
                 <a href="home.html" aria-current="page">
                     <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>

--- a/howtobuy.html
+++ b/howtobuy.html
@@ -20,7 +20,12 @@
                 </span>
             </a>
         </div>
-        <ul class="global-icon-nav">
+        <button class="nav-menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Open navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="global-icon-nav">
             <li>
                 <a href="home.html">
                     <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>

--- a/js/main.js
+++ b/js/main.js
@@ -163,7 +163,39 @@ function setupBlogDiscovery() {
     applyFilter("all");
 }
 
+function setupNavigationMenu() {
+    var toggle = document.querySelector(".nav-menu-toggle");
+    var menu = document.querySelector(".global-icon-nav");
+
+    if (!toggle || !menu) {
+        return;
+    }
+
+    toggle.addEventListener("click", function () {
+        var isOpen = document.body.classList.toggle("nav-open");
+        toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+        toggle.setAttribute("aria-label", isOpen ? "Close navigation menu" : "Open navigation menu");
+    });
+
+    menu.addEventListener("click", function (event) {
+        if (event.target.closest("a")) {
+            document.body.classList.remove("nav-open");
+            toggle.setAttribute("aria-expanded", "false");
+            toggle.setAttribute("aria-label", "Open navigation menu");
+        }
+    });
+
+    document.addEventListener("keydown", function (event) {
+        if (event.key === "Escape") {
+            document.body.classList.remove("nav-open");
+            toggle.setAttribute("aria-expanded", "false");
+            toggle.setAttribute("aria-label", "Open navigation menu");
+        }
+    });
+}
+
 document.addEventListener("DOMContentLoaded", function () {
+    setupNavigationMenu();
     setupProgressTracker();
     setupBlogDiscovery();
 });

--- a/moreresources.html
+++ b/moreresources.html
@@ -22,7 +22,12 @@
                 </span>
             </a>
         </div>
-        <ul class="global-icon-nav">
+        <button class="nav-menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Open navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="global-icon-nav">
             <li>
                 <a href="home.html">
                     <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>

--- a/whatif.html
+++ b/whatif.html
@@ -20,7 +20,12 @@
                 </span>
             </a>
         </div>
-        <ul class="global-icon-nav">
+        <button class="nav-menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Open navigation menu">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="global-icon-nav">
             <li>
                 <a href="home.html">
                     <span class="nav-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10.5 12 4l8 6.5"/><path d="M6.5 9.5V20h11V9.5"/></svg></span>


### PR DESCRIPTION
### Motivation
- Replace the homepage icon strip on mobile with a compact, accessible hamburger menu so the original site’s icon tabs (Home, About, Blog, Buy, Learn, Tools) are reachable from the current layout.

### Description
- Inserted an accessible hamburger toggle button and switched the navigation UL to `id="primary-navigation"` so the icon tabs live inside the hamburger for each HTML page (`home.html`, `about.html`, `blog.html`, `howtobuy.html`, `moreresources.html`, `explain-bitcoin-to-anyone.html`, `whatif.html`).
- Implemented homepage-specific CSS to render the hamburger as a two-column dropdown grid with active-state highlighting and animated toggle visuals (`css/style.css`).
- Added `setupNavigationMenu()` to `js/main.js` to toggle `body.nav-open`, update ARIA attributes, close the menu after link selection, and close on `Escape`, and called it on `DOMContentLoaded`.
- Kept existing icon SVGs and labels; layout and accessibility changes are limited to the navigation markup, CSS, and the new JS menu behavior.

### Testing
- Ran `node --check js/main.js` and it succeeded.
- Started a local server with `python3 -m http.server 4173` and fetched the homepage with `curl -fsS http://localhost:4173/home.html` which succeeded.
- Executed a Python assertion that verifies `class="nav-menu-toggle"` and `id="primary-navigation" class="global-icon-nav"` are present in every HTML page and it passed.
- Attempted to capture a browser screenshot with Playwright using `node -e "require('playwright')..."` which failed because Playwright/browser tooling is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51a1965a3883268cd7edddfe92e4aa)