### PR TITLE
Add inflation-adjusted “Wealth Race” calculator with chart and table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2942,3 +2942,162 @@ body:has(.app-page) {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
+
+.wealth-race-calculator {
+    position: relative;
+    overflow: hidden;
+    grid-column: 1 / -1;
+}
+
+.wealth-race-calculator::before {
+    content: '';
+    position: absolute;
+    inset: -8rem -6rem auto auto;
+    width: 18rem;
+    height: 18rem;
+    border-radius: 999px;
+    background: radial-gradient(circle, rgba(247, 147, 26, 0.26), transparent 68%);
+    pointer-events: none;
+}
+
+.calculator-kicker {
+    position: relative;
+    z-index: 1;
+    width: fit-content;
+    margin-bottom: 0.65rem;
+    padding: 0.25rem 0.65rem;
+    border: 1px solid rgba(247, 147, 26, 0.35);
+    border-radius: 999px;
+    color: var(--orange-2);
+    background: rgba(247, 147, 26, 0.10);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.wealth-input-grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.85rem;
+    margin-top: 1rem;
+}
+
+.range-readout {
+    display: inline-flex;
+    margin-top: 0.35rem;
+    color: var(--orange-2);
+    font-weight: 800;
+}
+
+.wealth-summary {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+    gap: 0.7rem;
+    margin: 1rem 0;
+}
+
+.wealth-summary div {
+    padding: 0.85rem;
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 12px;
+    background: rgba(5, 7, 10, 0.48);
+}
+
+.wealth-summary strong,
+.wealth-summary span {
+    display: block;
+}
+
+.wealth-summary strong {
+    color: #ffffff;
+    font-size: clamp(1.15rem, 4vw, 1.55rem);
+    line-height: 1.1;
+}
+
+.wealth-summary span {
+    margin-top: 0.35rem;
+    color: rgba(231, 223, 210, 0.78);
+    font-size: 0.78rem;
+    line-height: 1.35;
+}
+
+#wealth-race-chart {
+    position: relative;
+    z-index: 1;
+    min-height: 260px;
+    margin-top: 0.75rem;
+}
+
+.wealth-table-wrap {
+    position: relative;
+    z-index: 1;
+    margin-top: 1rem;
+    overflow-x: auto;
+}
+
+.wealth-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 620px;
+    color: var(--text);
+    font-size: 0.9rem;
+}
+
+.wealth-table th,
+.wealth-table td {
+    padding: 0.7rem 0.65rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.10);
+    text-align: left;
+}
+
+.wealth-table th {
+    color: rgba(231, 223, 210, 0.72);
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.wealth-dot {
+    display: inline-block;
+    width: 0.65rem;
+    height: 0.65rem;
+    margin-right: 0.45rem;
+    border-radius: 999px;
+    background: var(--dot-color);
+    box-shadow: 0 0 16px var(--dot-color);
+}
+
+.wealth-table .positive {
+    color: var(--green);
+    font-weight: 800;
+}
+
+.wealth-table .negative {
+    color: var(--danger);
+    font-weight: 800;
+}
+
+.calculator-note {
+    margin: 0.85rem 0 0;
+    color: rgba(231, 223, 210, 0.72);
+    font-size: 0.82rem;
+}
+
+.app-page .wealth-race-calculator h2 {
+    text-align: left;
+}
+
+.app-page .wealth-race-calculator input[type="range"] {
+    accent-color: var(--orange);
+}
+
+@media (min-width: 768px) {
+    .app-page .wealth-race-calculator {
+        padding: 1.25rem;
+    }
+}

--- a/js/roi.js
+++ b/js/roi.js
@@ -346,3 +346,137 @@ const convictionBuy = document.getElementById('conviction-buy');
 if (convictionBuy) {
     convictionBuy.addEventListener('click', () => handleConvictionChoice('buy'));
 }
+
+const wealthRaceConfig = [
+    { key: 'savings', label: 'Bank savings', rate: 0.01, color: '#94a3b8' },
+    { key: 'treasuries', label: 'Treasury bonds', rate: 0.04, color: '#60a5fa' },
+    { key: 'sp500', label: 'S&P 500', rate: 0.10, color: '#34d399' },
+    { key: 'bitcoin', label: 'Bitcoin', rate: 0.24, color: '#f7931a' }
+];
+
+let wealthRaceChart;
+
+function formatDollars(value) {
+    return `$${formatCurrency(value)}`;
+}
+
+function updateRangeReadout(inputId, displayId, suffix) {
+    const input = document.getElementById(inputId);
+    const display = document.getElementById(displayId);
+    if (!input || !display) return;
+    const value = parseFloat(input.value);
+    display.textContent = suffix === 'years'
+        ? `${value} year${value === 1 ? '' : 's'}`
+        : `${value}%`;
+}
+
+function calculateCompoundedValue(principal, rate, years) {
+    return principal * Math.pow(1 + rate, years);
+}
+
+function renderWealthRace() {
+    const amountInput = document.getElementById('wealth-amount');
+    const yearsInput = document.getElementById('wealth-years');
+    const inflationInput = document.getElementById('inflation-rate');
+    const bitcoinInput = document.getElementById('bitcoin-rate');
+    const tableBody = document.getElementById('wealth-table-body');
+    const summary = document.getElementById('wealth-summary');
+    const canvas = document.getElementById('wealth-race-chart');
+
+    if (!amountInput || !yearsInput || !inflationInput || !bitcoinInput || !tableBody || !summary || !canvas) return;
+
+    updateRangeReadout('wealth-years', 'wealth-years-display', 'years');
+    updateRangeReadout('inflation-rate', 'inflation-rate-display', 'percent');
+    updateRangeReadout('bitcoin-rate', 'bitcoin-rate-display', 'percent');
+
+    const principal = parseNumber(amountInput.value) || 0;
+    const years = parseInt(yearsInput.value, 10);
+    const inflationRate = parseFloat(inflationInput.value) / 100;
+    const bitcoinRate = parseFloat(bitcoinInput.value) / 100;
+    const inflationAdjustedStartingPower = principal / Math.pow(1 + inflationRate, years);
+
+    const rows = wealthRaceConfig.map(option => {
+        const rate = option.key === 'bitcoin' ? bitcoinRate : option.rate;
+        const nominal = calculateCompoundedValue(principal, rate, years);
+        const real = nominal / Math.pow(1 + inflationRate, years);
+        return { ...option, rate, nominal, real };
+    });
+
+    const bitcoin = rows.find(row => row.key === 'bitcoin');
+    const savings = rows.find(row => row.key === 'savings');
+    const bestNonBitcoin = rows.filter(row => row.key !== 'bitcoin').sort((a, b) => b.real - a.real)[0];
+    const bitcoinMultiple = bestNonBitcoin && bestNonBitcoin.real > 0 ? bitcoin.real / bestNonBitcoin.real : 0;
+
+    summary.innerHTML = `
+        <div><strong>${formatDollars(principal)}</strong><span>Starting money</span></div>
+        <div><strong>${formatDollars(inflationAdjustedStartingPower)}</strong><span>Cash buying power after ${years} years at ${formatPercent(inflationRate)} inflation</span></div>
+        <div><strong>${bitcoinMultiple.toFixed(1)}×</strong><span>Bitcoin real-value multiple vs. best non-Bitcoin option</span></div>
+        <div><strong>${formatDollars(savings.real - principal)}</strong><span>Savings real gain/loss vs. today</span></div>
+    `;
+
+    tableBody.innerHTML = rows.map(row => {
+        const realDelta = row.real - principal;
+        const deltaClass = realDelta >= 0 ? 'positive' : 'negative';
+        return `
+            <tr>
+                <td><span class="wealth-dot" style="--dot-color: ${row.color}"></span>${row.label}</td>
+                <td>${formatPercent(row.rate)}</td>
+                <td>${formatDollars(row.nominal)}</td>
+                <td class="${deltaClass}">${formatDollars(row.real)} (${realDelta >= 0 ? '+' : ''}${formatDollars(realDelta)})</td>
+            </tr>
+        `;
+    }).join('');
+
+    if (typeof Chart === 'undefined') return;
+
+    const chartYears = Array.from({ length: years + 1 }, (_, index) => index);
+    const datasets = rows.map(row => ({
+        label: row.label,
+        data: chartYears.map(year => calculateCompoundedValue(principal, row.rate, year)),
+        borderColor: row.color,
+        backgroundColor: row.color,
+        tension: 0.35,
+        pointRadius: yearPointRadius(years)
+    }));
+
+    datasets.push({
+        label: 'Inflation hurdle',
+        data: chartYears.map(year => calculateCompoundedValue(principal, inflationRate, year)),
+        borderColor: '#ef4444',
+        backgroundColor: '#ef4444',
+        borderDash: [8, 6],
+        tension: 0.35,
+        pointRadius: yearPointRadius(years)
+    });
+
+    const ctx = canvas.getContext('2d');
+    if (wealthRaceChart) wealthRaceChart.destroy();
+    wealthRaceChart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: chartYears, datasets },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { labels: { color: '#f5f1e8' } },
+                tooltip: { callbacks: { label: context => `${context.dataset.label}: ${formatDollars(context.parsed.y)}` } }
+            },
+            scales: {
+                x: { title: { display: true, text: 'Years', color: '#e7dfd2' }, ticks: { color: '#cbd5e1' }, grid: { color: 'rgba(255,255,255,0.08)' } },
+                y: { ticks: { color: '#cbd5e1', callback: value => formatDollars(value) }, grid: { color: 'rgba(255,255,255,0.08)' } }
+            }
+        }
+    });
+}
+
+function yearPointRadius(years) {
+    return years > 18 ? 0 : 3;
+}
+
+['wealth-amount', 'wealth-years', 'inflation-rate', 'bitcoin-rate'].forEach(id => {
+    const element = document.getElementById(id);
+    if (element) element.addEventListener('input', renderWealthRace);
+});
+
+if (document.getElementById('wealth-race-chart')) {
+    renderWealthRace();
+}

--- a/whatif.html
+++ b/whatif.html
@@ -127,6 +127,49 @@
                 <p id="result-million"></p>
             </div>
 
+
+            <div class="calculator-card wealth-race-calculator">
+                <div class="calculator-kicker">Inflation-adjusted comparison</div>
+                <h2>The $10,000 Wealth Race</h2>
+                <p><small>Compare a bank savings account, Treasury bonds, the S&amp;P 500, and Bitcoin against a default 7% inflation hurdle.</small></p>
+                <div class="wealth-input-grid">
+                    <div>
+                        <label for="wealth-amount">Starting amount (USD):</label>
+                        <input type="text" id="wealth-amount" value="10,000" placeholder="e.g. 10,000">
+                    </div>
+                    <div>
+                        <label for="wealth-years">Years invested:</label>
+                        <input type="range" id="wealth-years" min="1" max="40" value="10">
+                        <span class="range-readout" id="wealth-years-display">10 years</span>
+                    </div>
+                    <div>
+                        <label for="inflation-rate">Inflation rate:</label>
+                        <input type="range" id="inflation-rate" min="0" max="15" step="0.5" value="7">
+                        <span class="range-readout" id="inflation-rate-display">7%</span>
+                    </div>
+                    <div>
+                        <label for="bitcoin-rate">Bitcoin annual return:</label>
+                        <input type="range" id="bitcoin-rate" min="0" max="60" step="1" value="24">
+                        <span class="range-readout" id="bitcoin-rate-display">24%</span>
+                    </div>
+                </div>
+                <div class="wealth-summary" id="wealth-summary" aria-live="polite"></div>
+                <canvas id="wealth-race-chart" aria-label="Investment comparison chart"></canvas>
+                <div class="wealth-table-wrap">
+                    <table class="wealth-table">
+                        <thead>
+                            <tr>
+                                <th>Option</th>
+                                <th>Annual return</th>
+                                <th>Nominal value</th>
+                                <th>Inflation-adjusted</th>
+                            </tr>
+                        </thead>
+                        <tbody id="wealth-table-body"></tbody>
+                    </table>
+                </div>
+                <p class="calculator-note">This educational model uses fixed annualized assumptions, not guaranteed future returns.</p>
+            </div>
             <div class="calculator-card growth-calculator">
                 <h2>Compounded annual growth projection</h2>
                 <div>


### PR DESCRIPTION
### Motivation
- Provide an easy visual comparison showing how different investments (bank savings, Treasury bonds, S&P 500, Bitcoin) perform nominally and after inflation to illustrate purchasing-power outcomes. 
- Let users experiment with key assumptions (starting amount, investment horizon, inflation, Bitcoin annual return) using accessible sliders and readouts. 
- Add a polished, responsive UI element that integrates with the existing calculators page and uses Chart.js for visual storytelling.

### Description
- Added a new calculator card to `whatif.html` named the "$10,000 Wealth Race" with inputs for starting amount, years, inflation rate, and an adjustable Bitcoin annual-return slider. 
- Implemented the calculation and UI logic in `js/roi.js`, including `wealthRaceConfig`, `renderWealthRace()`, compound-growth and inflation-adjusted computations, Chart.js dataset construction, table rendering, and live range readouts. 
- Added defensive checks so the chart code exits gracefully when `Chart` is not present and wired input `input` events to re-render the visualization. 
- Added responsive styling and layout in `css/style.css` for the new card, summary tiles, chart canvas, table, range readouts, and positive/negative result styling.

### Testing
- Ran `node --check js/roi.js` to validate the modified JavaScript file syntax, which succeeded. 
- Ran `python3 -m compileall .` to sanity-check Python tooling used during development, which completed (no syntax errors reported). 
- Served the site locally and ran `curl -I http://127.0.0.1:4173/whatif.html` to verify the page is reachable, which returned HTTP 200. 
- Attempted an automated screenshot capture using Playwright, but installing Playwright via `npx` failed due to a restricted npm registry (403), so the visual end-to-end screenshot step could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540c90da5083269c45f5afd3f5668a)