### PR TITLE
Focus tools page on $10,000 Wealth Race calculator; polish UI and chart

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2946,66 +2946,143 @@ body:has(.app-page) {
 .wealth-race-calculator {
     position: relative;
     overflow: hidden;
-    grid-column: 1 / -1;
+    max-width: 1180px;
+    margin: 0 auto 3rem;
+    padding: clamp(1.25rem, 3vw, 2rem);
+    border: 1px solid rgba(247, 147, 26, 0.22);
+    border-radius: 30px;
+    background:
+        radial-gradient(circle at top right, rgba(247, 147, 26, 0.28), transparent 32rem),
+        linear-gradient(145deg, rgba(19, 24, 31, 0.98), rgba(7, 9, 11, 0.98));
+    box-shadow: 0 28px 70px rgba(0, 0, 0, 0.42);
+}
+
+.app-page.calculators {
+    max-width: 1180px;
 }
 
 .wealth-race-calculator::before {
     content: '';
     position: absolute;
-    inset: -8rem -6rem auto auto;
-    width: 18rem;
-    height: 18rem;
+    inset: -10rem -7rem auto auto;
+    width: 26rem;
+    height: 26rem;
     border-radius: 999px;
-    background: radial-gradient(circle, rgba(247, 147, 26, 0.26), transparent 68%);
+    background: radial-gradient(circle, rgba(247, 147, 26, 0.24), transparent 68%);
     pointer-events: none;
 }
 
-.calculator-kicker {
+.wealth-hero-copy,
+.wealth-dashboard {
     position: relative;
     z-index: 1;
+}
+
+.wealth-hero-copy {
+    max-width: 760px;
+}
+
+.wealth-hero-copy h2 {
+    margin: 0;
+    color: #ffffff;
+    font-size: clamp(2.2rem, 7vw, 4.5rem);
+    line-height: 0.95;
+    letter-spacing: -0.06em;
+    text-align: left;
+}
+
+.wealth-hero-copy p {
+    max-width: 720px;
+    color: rgba(231, 223, 210, 0.82);
+    font-size: clamp(1rem, 2vw, 1.18rem);
+}
+
+.calculator-kicker {
     width: fit-content;
-    margin-bottom: 0.65rem;
-    padding: 0.25rem 0.65rem;
-    border: 1px solid rgba(247, 147, 26, 0.35);
+    margin-bottom: 0.85rem;
+    padding: 0.3rem 0.75rem;
+    border: 1px solid rgba(247, 147, 26, 0.42);
     border-radius: 999px;
     color: var(--orange-2);
-    background: rgba(247, 147, 26, 0.10);
+    background: rgba(247, 147, 26, 0.12);
     font-size: 0.72rem;
     font-weight: 800;
     letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
-.wealth-input-grid {
-    position: relative;
-    z-index: 1;
+.wealth-dashboard {
+    margin-top: 1.5rem;
+}
+
+.wealth-controls {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 0.85rem;
-    margin-top: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: 0.9rem;
+    margin: 0;
+}
+
+.control-card {
+    padding: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.055);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.control-card label {
+    display: block;
+    margin-bottom: 0.55rem;
+    color: rgba(245, 241, 232, 0.92);
+    font-size: 0.82rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.money-input-wrap {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--orange-2);
+    font-size: 1.4rem;
+    font-weight: 900;
+}
+
+.money-input-wrap input,
+.wealth-controls input[type="text"] {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    color: #ffffff;
+    font-size: 1.4rem;
+    font-weight: 900;
+    outline: none;
+}
+
+.wealth-controls input[type="range"] {
+    width: 100%;
+    accent-color: var(--orange);
 }
 
 .range-readout {
     display: inline-flex;
-    margin-top: 0.35rem;
+    margin-top: 0.45rem;
     color: var(--orange-2);
-    font-weight: 800;
+    font-weight: 900;
 }
 
 .wealth-summary {
-    position: relative;
-    z-index: 1;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
-    gap: 0.7rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.85rem;
     margin: 1rem 0;
 }
 
 .wealth-summary div {
-    padding: 0.85rem;
+    padding: 1rem;
     border: 1px solid rgba(255, 255, 255, 0.10);
-    border-radius: 12px;
-    background: rgba(5, 7, 10, 0.48);
+    border-radius: 18px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.035));
 }
 
 .wealth-summary strong,
@@ -3015,58 +3092,94 @@ body:has(.app-page) {
 
 .wealth-summary strong {
     color: #ffffff;
-    font-size: clamp(1.15rem, 4vw, 1.55rem);
-    line-height: 1.1;
+    font-size: clamp(1.2rem, 4vw, 1.75rem);
+    line-height: 1.08;
 }
 
 .wealth-summary span {
-    margin-top: 0.35rem;
-    color: rgba(231, 223, 210, 0.78);
-    font-size: 0.78rem;
+    margin-top: 0.4rem;
+    color: rgba(231, 223, 210, 0.76);
+    font-size: 0.8rem;
     line-height: 1.35;
 }
 
+.chart-shell {
+    margin-top: 1rem;
+    padding: clamp(1rem, 2.5vw, 1.35rem);
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 24px;
+    background: rgba(5, 7, 10, 0.58);
+}
+
+.chart-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: start;
+    margin-bottom: 1rem;
+}
+
+.chart-eyebrow,
+#wealth-chart-note {
+    margin: 0;
+    color: rgba(231, 223, 210, 0.68);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+}
+
+.chart-header h3 {
+    margin: 0.1rem 0 0;
+    color: #ffffff;
+    font-size: clamp(1.2rem, 3vw, 1.8rem);
+}
+
 #wealth-race-chart {
-    position: relative;
-    z-index: 1;
-    min-height: 260px;
-    margin-top: 0.75rem;
+    display: block;
+    width: 100%;
+    height: clamp(360px, 52vw, 560px) !important;
 }
 
 .wealth-table-wrap {
-    position: relative;
-    z-index: 1;
     margin-top: 1rem;
     overflow-x: auto;
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.045);
 }
 
 .wealth-table {
     width: 100%;
     border-collapse: collapse;
-    min-width: 620px;
+    min-width: 760px;
     color: var(--text);
-    font-size: 0.9rem;
+    font-size: 0.92rem;
 }
 
 .wealth-table th,
 .wealth-table td {
-    padding: 0.7rem 0.65rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.10);
+    padding: 0.85rem 0.8rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.09);
     text-align: left;
 }
 
+.wealth-table tr:last-child td {
+    border-bottom: 0;
+}
+
 .wealth-table th {
-    color: rgba(231, 223, 210, 0.72);
-    font-size: 0.75rem;
-    letter-spacing: 0.05em;
+    color: rgba(231, 223, 210, 0.68);
+    font-size: 0.73rem;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
 }
 
 .wealth-dot {
     display: inline-block;
-    width: 0.65rem;
-    height: 0.65rem;
-    margin-right: 0.45rem;
+    width: 0.7rem;
+    height: 0.7rem;
+    margin-right: 0.5rem;
     border-radius: 999px;
     background: var(--dot-color);
     box-shadow: 0 0 16px var(--dot-color);
@@ -3074,30 +3187,44 @@ body:has(.app-page) {
 
 .wealth-table .positive {
     color: var(--green);
-    font-weight: 800;
+    font-weight: 900;
 }
 
 .wealth-table .negative {
     color: var(--danger);
-    font-weight: 800;
+    font-weight: 900;
+}
+
+.wealth-insight {
+    margin-top: 1rem;
+    padding: 1rem 1.1rem;
+    border: 1px solid rgba(247, 147, 26, 0.24);
+    border-radius: 18px;
+    background: rgba(247, 147, 26, 0.08);
+}
+
+.wealth-insight h3 {
+    margin: 0 0 0.35rem;
+    color: #ffffff;
+}
+
+.wealth-insight p {
+    margin: 0;
+    color: rgba(231, 223, 210, 0.82);
 }
 
 .calculator-note {
-    margin: 0.85rem 0 0;
-    color: rgba(231, 223, 210, 0.72);
+    margin: 0.9rem 0 0;
+    color: rgba(231, 223, 210, 0.68);
     font-size: 0.82rem;
 }
 
-.app-page .wealth-race-calculator h2 {
-    text-align: left;
-}
+@media (max-width: 720px) {
+    .chart-header {
+        display: block;
+    }
 
-.app-page .wealth-race-calculator input[type="range"] {
-    accent-color: var(--orange);
-}
-
-@media (min-width: 768px) {
-    .app-page .wealth-race-calculator {
-        padding: 1.25rem;
+    #wealth-chart-note {
+        margin-top: 0.4rem;
     }
 }

--- a/js/roi.js
+++ b/js/roi.js
@@ -1,8 +1,3 @@
-function formatDate(inputDate) {
-    const parts = inputDate.split('-');
-    return parts[2] + '-' + parts[1] + '-' + parts[0];
-}
-
 function parseNumber(value) {
     return parseFloat(value.replace(/,/g, ''));
 }
@@ -11,340 +6,8 @@ function formatCurrency(value) {
     return Math.round(value).toLocaleString();
 }
 
-function calculateROI() {
-    const amount = parseNumber(document.getElementById('investment').value);
-    const date = document.getElementById('purchase-date').value;
-    const resultEl = document.getElementById('result');
-
-    if (!amount || !date) {
-        resultEl.textContent = 'Please enter a valid amount and date.';
-        return;
-    }
-
-    const formattedDate = formatDate(date);
-    fetch('https://api.coingecko.com/api/v3/coins/bitcoin/history?date=' + formattedDate)
-        .then(response => response.json())
-        .then(data => {
-            const pastPrice = data.market_data.current_price.usd;
-            return fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd')
-                .then(r => r.json())
-                .then(current => {
-                    const currentPrice = current.bitcoin.usd;
-                    const btcAmount = amount / pastPrice;
-                    const valueToday = btcAmount * currentPrice;
-                    resultEl.textContent = `Your $${formatCurrency(amount)} investment would be worth $${formatCurrency(valueToday)} today.`;
-                });
-        })
-        .catch(() => {
-            resultEl.textContent = 'Unable to retrieve price data.';
-        });
-}
-
-document.getElementById('calc-btn').addEventListener('click', calculateROI);
-
-function calculateMillion() {
-    const amount = parseNumber(document.getElementById('invest-million').value);
-    const resultEl = document.getElementById('result-million');
-
-    if (!amount) {
-        resultEl.textContent = 'Please enter a valid amount.';
-        return;
-    }
-
-    fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd')
-        .then(r => r.json())
-        .then(data => {
-            const currentPrice = data.bitcoin.usd;
-            const btcAmount = amount / currentPrice;
-            const futureValue = btcAmount * 1000000;
-            resultEl.textContent = `If Bitcoin reaches $1,000,000, your investment would be worth $${formatCurrency(futureValue)}.`;
-        })
-        .catch(() => {
-            resultEl.textContent = 'Unable to retrieve price data.';
-        });
-}
-
-document.getElementById('calc-million-btn').addEventListener('click', calculateMillion);
-
-function updateCagrDisplay() {
-    const rateInput = document.getElementById('cagr-rate');
-    const display = document.getElementById('cagr-rate-display');
-    if (rateInput && display) {
-        display.textContent = rateInput.value + '%';
-    }
-}
-
-let cagrChart;
-
-function calculateCagr() {
-    const amount = parseNumber(document.getElementById('cagr-amount').value);
-    const rate = parseFloat(document.getElementById('cagr-rate').value) / 100;
-    const resultEl = document.getElementById('cagr-result');
-
-    if (!amount) {
-        resultEl.textContent = 'Please enter a valid amount.';
-        return;
-    }
-
-    const displayYears = [1, 3, 5, 10, 20];
-    let output = '';
-    displayYears.forEach(y => {
-        const value = amount * Math.pow(1 + rate, y);
-        output += `${y} year${y > 1 ? 's' : ''}: $${formatCurrency(value)}<br>`;
-    });
-    resultEl.innerHTML = output;
-
-    const chartYears = Array.from({ length: 21 }, (_, i) => i);
-    const chartValues = chartYears.map(y => amount * Math.pow(1 + rate, y));
-    const ctx = document.getElementById('cagr-chart').getContext('2d');
-    if (cagrChart) cagrChart.destroy();
-    cagrChart = new Chart(ctx, {
-        type: 'line',
-        data: {
-            labels: chartYears,
-            datasets: [{
-                label: 'Projected value',
-                data: chartValues,
-                borderColor: 'rgba(75, 192, 192, 1)',
-                backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                fill: false
-            }]
-        },
-        options: {
-            plugins: {
-                tooltip: {
-                    callbacks: {
-                        label: ctx => `$${formatCurrency(ctx.parsed.y)}`
-                    }
-                }
-            },
-            scales: {
-                y: {
-                    ticks: {
-                        callback: val => '$' + formatCurrency(val)
-                    }
-                }
-            }
-        }
-    });
-}
-
-['growth-bear','growth-base','growth-bull'].forEach(id => {
-    const el = document.getElementById(id);
-    if (el) {
-        el.addEventListener('click', () => {
-            const rateInput = document.getElementById('cagr-rate');
-            if (id === 'growth-bear') rateInput.value = 16;
-            if (id === 'growth-base') rateInput.value = 24;
-            if (id === 'growth-bull') rateInput.value = 30;
-            updateCagrDisplay();
-        });
-    }
-});
-
-const cagrRateInput = document.getElementById('cagr-rate');
-if (cagrRateInput) {
-    cagrRateInput.addEventListener('input', updateCagrDisplay);
-}
-
-const cagrCalcBtn = document.getElementById('cagr-calc-btn');
-if (cagrCalcBtn) {
-    cagrCalcBtn.addEventListener('click', calculateCagr);
-}
-
-const convictionScenarios = {
-    2017: [
-        { drop: 0.38, headline: 'Headlines scream: "Bitcoin is dead."', friend: 'Your cousin says it is just a fad.' },
-        { drop: 0.42, headline: 'Price crashes again.', friend: 'A group chat says you should have sold.' },
-        { drop: 0.55, headline: 'Macro panic hits risk assets.', friend: 'A friend asks if crypto is over forever.' },
-        { drop: 0.3, headline: 'Regulators threaten a crackdown.', friend: 'Someone sends you a panic meme.' }
-    ],
-    2021: [
-        { drop: 0.32, headline: 'Leverage wipes out the market.', friend: 'Your colleague says you got lucky.' },
-        { drop: 0.4, headline: 'Media says the top is in.', friend: 'A friend claims Bitcoin will be replaced.' },
-        { drop: 0.28, headline: 'Exchange liquidity dries up.', friend: 'Your sibling says they sold.' },
-        { drop: 0.5, headline: 'Another brutal leg down.', friend: 'Someone tells you to stop the pain.' }
-    ],
-    2024: [
-        { drop: 0.25, headline: 'ETFs launch, then price fades.', friend: 'A friend says institutions are dumping.' },
-        { drop: 0.33, headline: 'Volatility spikes overnight.', friend: 'A group chat posts "told you so".' },
-        { drop: 0.2, headline: 'Macro headlines rattle markets.', friend: 'Someone says Bitcoin is too risky.' },
-        { drop: 0.3, headline: 'A sudden flush shakes out weak hands.', friend: 'A co-worker asks if you sold yet.' }
-    ]
-};
-
-const convictionState = {
-    active: false,
-    step: 0,
-    startPrice: 0,
-    currentPrice: 0,
-    btcHoldings: 0,
-    cash: 0,
-    totalInvested: 0,
-    scenario: [],
-    soldOut: false
-};
-
-function setConvictionButtons(enabled) {
-    ['conviction-sell', 'conviction-hold', 'conviction-buy'].forEach(id => {
-        const btn = document.getElementById(id);
-        if (btn) btn.disabled = !enabled;
-    });
-}
-
-function addConvictionLog(message) {
-    const log = document.getElementById('conviction-log');
-    if (!log) return;
-    const entry = document.createElement('div');
-    entry.className = 'simulator-entry';
-    entry.innerHTML = message;
-    log.prepend(entry);
-}
-
 function formatPercent(value) {
-    return `${Math.round(value * 100)}%`;
-}
-
-function updateConvictionStatus(text) {
-    const status = document.getElementById('conviction-status');
-    if (status) status.textContent = text;
-}
-
-function getHistoryPrice(date) {
-    const formattedDate = formatDate(date);
-    return fetch(`https://api.coingecko.com/api/v3/coins/bitcoin/history?date=${formattedDate}`)
-        .then(response => response.json())
-        .then(data => data.market_data.current_price.usd);
-}
-
-function getCurrentPrice() {
-    return fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd')
-        .then(response => response.json())
-        .then(data => data.bitcoin.usd);
-}
-
-function startConvictionSimulation() {
-    const amount = parseNumber(document.getElementById('conviction-amount').value);
-    const year = document.getElementById('conviction-year').value;
-
-    if (!amount || !year) {
-        updateConvictionStatus('Enter a starting amount and select a buy date.');
-        return;
-    }
-
-    const date = `${year}-01-01`;
-    updateConvictionStatus('Loading historical price data...');
-    setConvictionButtons(false);
-    document.getElementById('conviction-log').innerHTML = '';
-
-    Promise.all([getHistoryPrice(date), getCurrentPrice()])
-        .then(([startPrice, currentPrice]) => {
-            convictionState.active = true;
-            convictionState.step = 0;
-            convictionState.startPrice = startPrice;
-            convictionState.currentPrice = startPrice;
-            convictionState.btcHoldings = amount / startPrice;
-            convictionState.cash = 0;
-            convictionState.totalInvested = amount;
-            convictionState.scenario = convictionScenarios[year] || [];
-            convictionState.soldOut = false;
-            convictionState.finalPrice = currentPrice;
-
-            addConvictionLog(`You bought <strong>${(convictionState.btcHoldings).toFixed(4)} BTC</strong> at <strong>$${formatCurrency(startPrice)}</strong> per coin.`);
-            updateConvictionStatus('The cycle begins. Brace yourself.');
-            setConvictionButtons(true);
-            showConvictionEvent();
-        })
-        .catch(() => {
-            updateConvictionStatus('Unable to retrieve price data. Please try again.');
-            setConvictionButtons(false);
-        });
-}
-
-function showConvictionEvent() {
-    if (!convictionState.active || convictionState.soldOut) return;
-
-    if (convictionState.step >= convictionState.scenario.length) {
-        finishConvictionSimulation();
-        return;
-    }
-
-    const event = convictionState.scenario[convictionState.step];
-    convictionState.currentPrice = convictionState.currentPrice * (1 - event.drop);
-    const dropFromEntry = 1 - convictionState.currentPrice / convictionState.startPrice;
-
-    addConvictionLog(
-        `<strong>Crash ${convictionState.step + 1}:</strong> ${event.headline}<br>` +
-        `Simulated price: <strong>$${formatCurrency(convictionState.currentPrice)}</strong> (${formatPercent(dropFromEntry)} below entry).<br>` +
-        `<em>Friend text:</em> "${event.friend}"`
-    );
-    updateConvictionStatus('What do you do next?');
-}
-
-function handleConvictionChoice(action) {
-    if (!convictionState.active) return;
-
-    if (action === 'sell') {
-        convictionState.cash += convictionState.btcHoldings * convictionState.currentPrice;
-        convictionState.btcHoldings = 0;
-        convictionState.soldOut = true;
-        addConvictionLog(`You sold everything at <strong>$${formatCurrency(convictionState.currentPrice)}</strong>.`);
-        finishConvictionSimulation();
-        return;
-    }
-
-    if (action === 'buy') {
-        const extraInvestment = 200;
-        convictionState.totalInvested += extraInvestment;
-        const extraBtc = extraInvestment / convictionState.currentPrice;
-        convictionState.btcHoldings += extraBtc;
-        addConvictionLog(`You bought $${formatCurrency(extraInvestment)} more and added <strong>${extraBtc.toFixed(4)} BTC</strong>.`);
-    } else {
-        addConvictionLog('You held your position and did nothing.');
-    }
-
-    convictionState.step += 1;
-    showConvictionEvent();
-}
-
-function finishConvictionSimulation() {
-    setConvictionButtons(false);
-    const finalValue = convictionState.btcHoldings * convictionState.finalPrice + convictionState.cash;
-    const hodlValue = (convictionState.totalInvested / convictionState.startPrice) * convictionState.finalPrice;
-
-    addConvictionLog(
-        `<strong>Cycle complete.</strong> Final price: <strong>$${formatCurrency(convictionState.finalPrice)}</strong>.<br>` +
-        `Your ending value: <strong>$${formatCurrency(finalValue)}</strong>.<br>` +
-        `If you simply HODLed every dollar invested: <strong>$${formatCurrency(hodlValue)}</strong>.`
-    );
-    addConvictionLog(
-        '<strong>What most people did:</strong> Many sold after the second crash and missed the rebound.'
-    );
-    addConvictionLog(
-        '<strong>Lesson:</strong> Bitcoin rewards conviction, not IQ.'
-    );
-    updateConvictionStatus('Simulation complete. Restart to try different choices.');
-    convictionState.active = false;
-}
-
-const convictionStart = document.getElementById('conviction-start');
-if (convictionStart) {
-    convictionStart.addEventListener('click', startConvictionSimulation);
-}
-
-const convictionSell = document.getElementById('conviction-sell');
-if (convictionSell) {
-    convictionSell.addEventListener('click', () => handleConvictionChoice('sell'));
-}
-
-const convictionHold = document.getElementById('conviction-hold');
-if (convictionHold) {
-    convictionHold.addEventListener('click', () => handleConvictionChoice('hold'));
-}
-
-const convictionBuy = document.getElementById('conviction-buy');
-if (convictionBuy) {
-    convictionBuy.addEventListener('click', () => handleConvictionChoice('buy'));
+    return `${Math.round(value * 1000) / 10}%`;
 }
 
 const wealthRaceConfig = [
@@ -358,6 +21,11 @@ let wealthRaceChart;
 
 function formatDollars(value) {
     return `$${formatCurrency(value)}`;
+}
+
+function formatSignedDollars(value) {
+    const sign = value >= 0 ? '+' : '-';
+    return `${sign}$${formatCurrency(Math.abs(value))}`;
 }
 
 function updateRangeReadout(inputId, displayId, suffix) {
@@ -381,9 +49,10 @@ function renderWealthRace() {
     const bitcoinInput = document.getElementById('bitcoin-rate');
     const tableBody = document.getElementById('wealth-table-body');
     const summary = document.getElementById('wealth-summary');
+    const insight = document.getElementById('wealth-insight');
     const canvas = document.getElementById('wealth-race-chart');
 
-    if (!amountInput || !yearsInput || !inflationInput || !bitcoinInput || !tableBody || !summary || !canvas) return;
+    if (!amountInput || !yearsInput || !inflationInput || !bitcoinInput || !tableBody || !summary || !insight || !canvas) return;
 
     updateRangeReadout('wealth-years', 'wealth-years-display', 'years');
     updateRangeReadout('inflation-rate', 'inflation-rate-display', 'percent');
@@ -393,7 +62,6 @@ function renderWealthRace() {
     const years = parseInt(yearsInput.value, 10);
     const inflationRate = parseFloat(inflationInput.value) / 100;
     const bitcoinRate = parseFloat(bitcoinInput.value) / 100;
-    const inflationAdjustedStartingPower = principal / Math.pow(1 + inflationRate, years);
 
     const rows = wealthRaceConfig.map(option => {
         const rate = option.key === 'bitcoin' ? bitcoinRate : option.rate;
@@ -405,13 +73,15 @@ function renderWealthRace() {
     const bitcoin = rows.find(row => row.key === 'bitcoin');
     const savings = rows.find(row => row.key === 'savings');
     const bestNonBitcoin = rows.filter(row => row.key !== 'bitcoin').sort((a, b) => b.real - a.real)[0];
+    const leader = [...rows].sort((a, b) => b.real - a.real)[0];
     const bitcoinMultiple = bestNonBitcoin && bestNonBitcoin.real > 0 ? bitcoin.real / bestNonBitcoin.real : 0;
+    const inflationHurdle = calculateCompoundedValue(principal, inflationRate, years);
 
     summary.innerHTML = `
         <div><strong>${formatDollars(principal)}</strong><span>Starting money</span></div>
-        <div><strong>${formatDollars(inflationAdjustedStartingPower)}</strong><span>Cash buying power after ${years} years at ${formatPercent(inflationRate)} inflation</span></div>
-        <div><strong>${bitcoinMultiple.toFixed(1)}×</strong><span>Bitcoin real-value multiple vs. best non-Bitcoin option</span></div>
-        <div><strong>${formatDollars(savings.real - principal)}</strong><span>Savings real gain/loss vs. today</span></div>
+        <div><strong>${formatDollars(inflationHurdle)}</strong><span>Future dollars needed to equal today's buying power</span></div>
+        <div><strong>${leader.label}</strong><span>Highest inflation-adjusted outcome after ${years} years</span></div>
+        <div><strong>${formatSignedDollars(savings.real - principal)}</strong><span>Savings real gain/loss vs. today</span></div>
     `;
 
     tableBody.innerHTML = rows.map(row => {
@@ -422,10 +92,16 @@ function renderWealthRace() {
                 <td><span class="wealth-dot" style="--dot-color: ${row.color}"></span>${row.label}</td>
                 <td>${formatPercent(row.rate)}</td>
                 <td>${formatDollars(row.nominal)}</td>
-                <td class="${deltaClass}">${formatDollars(row.real)} (${realDelta >= 0 ? '+' : ''}${formatDollars(realDelta)})</td>
+                <td>${formatDollars(row.real)}</td>
+                <td class="${deltaClass}">${formatSignedDollars(realDelta)}</td>
             </tr>
         `;
     }).join('');
+
+    insight.innerHTML = `
+        <h3>What the race shows</h3>
+        <p>At these settings, <strong>${leader.label}</strong> leads on real purchasing power. Bitcoin ends at <strong>${bitcoinMultiple.toFixed(1)}×</strong> the best non-Bitcoin real outcome, while the inflation hurdle means ${formatDollars(inflationHurdle)} future dollars are needed just to preserve the spending power of ${formatDollars(principal)} today.</p>
+    `;
 
     if (typeof Chart === 'undefined') return;
 
@@ -434,9 +110,15 @@ function renderWealthRace() {
         label: row.label,
         data: chartYears.map(year => calculateCompoundedValue(principal, row.rate, year)),
         borderColor: row.color,
-        backgroundColor: row.color,
-        tension: 0.35,
-        pointRadius: yearPointRadius(years)
+        backgroundColor: `${row.color}26`,
+        borderWidth: row.key === leader.key ? 4 : 2.5,
+        fill: row.key === 'bitcoin' ? 'origin' : false,
+        tension: 0.32,
+        pointRadius: yearPointRadius(years),
+        pointHoverRadius: 6,
+        pointBackgroundColor: row.color,
+        pointBorderColor: '#101418',
+        pointBorderWidth: 2
     }));
 
     datasets.push({
@@ -445,8 +127,9 @@ function renderWealthRace() {
         borderColor: '#ef4444',
         backgroundColor: '#ef4444',
         borderDash: [8, 6],
+        borderWidth: 2,
         tension: 0.35,
-        pointRadius: yearPointRadius(years)
+        pointRadius: 0
     });
 
     const ctx = canvas.getContext('2d');
@@ -456,13 +139,43 @@ function renderWealthRace() {
         data: { labels: chartYears, datasets },
         options: {
             responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
             plugins: {
-                legend: { labels: { color: '#f5f1e8' } },
-                tooltip: { callbacks: { label: context => `${context.dataset.label}: ${formatDollars(context.parsed.y)}` } }
+                legend: {
+                    position: 'bottom',
+                    labels: {
+                        color: '#f5f1e8',
+                        usePointStyle: true,
+                        pointStyle: 'circle',
+                        padding: 18,
+                        font: { family: 'Inter', weight: '700' }
+                    }
+                },
+                tooltip: {
+                    backgroundColor: 'rgba(7, 9, 11, 0.94)',
+                    borderColor: 'rgba(247, 147, 26, 0.35)',
+                    borderWidth: 1,
+                    padding: 12,
+                    titleColor: '#ffffff',
+                    bodyColor: '#e7dfd2',
+                    callbacks: {
+                        title: items => `Year ${items[0].label}`,
+                        label: context => `${context.dataset.label}: ${formatDollars(context.parsed.y)}`
+                    }
+                }
             },
             scales: {
-                x: { title: { display: true, text: 'Years', color: '#e7dfd2' }, ticks: { color: '#cbd5e1' }, grid: { color: 'rgba(255,255,255,0.08)' } },
-                y: { ticks: { color: '#cbd5e1', callback: value => formatDollars(value) }, grid: { color: 'rgba(255,255,255,0.08)' } }
+                x: {
+                    title: { display: true, text: 'Years', color: '#e7dfd2', font: { weight: '800' } },
+                    ticks: { color: '#cbd5e1', maxRotation: 0 },
+                    grid: { color: 'rgba(255,255,255,0.06)' }
+                },
+                y: {
+                    beginAtZero: true,
+                    ticks: { color: '#cbd5e1', callback: value => formatDollars(value) },
+                    grid: { color: 'rgba(255,255,255,0.08)' }
+                }
             }
         }
     });

--- a/whatif.html
+++ b/whatif.html
@@ -68,93 +68,57 @@
     </nav>
     <main id="main-content" class="container app-page calculators">
         <header class="page-hero">
-            <p class="eyebrow">Interactive Tools</p>
-            <h1>Bitcoin What-If Calculators</h1>
-            <p class="lead">Model purchase dates, million-dollar scenarios, and long-term growth paths.</p>
+            <p class="eyebrow">Interactive Tool</p>
+            <h1>The $10,000 Wealth Race Calculator</h1>
+            <p class="lead">See how savings, bonds, stocks, and Bitcoin compete against inflation over time.</p>
         </header>
 
-        <div class="calculator-grid">
-            <div class="calculator-card roi-calculator">
-                <h2>If I had bought Bitcoin...</h2>
-                <p><small>This calculator works for purchase dates within the last 365 days.</small></p>
-                <div>
-                    <label for="investment">Amount in USD:</label>
-                    <input type="text" id="investment" placeholder="e.g. 10,000">
-                </div>
-                <div>
-                    <label for="purchase-date">Purchase date:</label>
-                    <input type="date" id="purchase-date">
-                </div>
-                <button id="calc-btn">Calculate</button>
-                <p id="result"></p>
-            </div>
-
-            <div class="calculator-card conviction-simulator">
-                <h2>Bitcoin Conviction Simulator</h2>
-                <p><small>Experience the emotional volatility of a cycle without risking real money.</small></p>
-                <div>
-                    <label for="conviction-amount">Starting amount (USD):</label>
-                    <input type="text" id="conviction-amount" placeholder="e.g. 1,000">
-                </div>
-                <div>
-                    <label for="conviction-year">Pick a buy date:</label>
-                    <select id="conviction-year">
-                        <option value="2017">January 2017</option>
-                        <option value="2021">January 2021</option>
-                        <option value="2024">January 2024</option>
-                    </select>
-                </div>
-                <button id="conviction-start">Start the simulation</button>
-                <div class="simulator-panel">
-                    <p id="conviction-status">Choose a buy date and start to see what happens.</p>
-                    <div class="simulator-actions">
-                        <button type="button" id="conviction-sell" disabled>Sell</button>
-                        <button type="button" id="conviction-hold" disabled>Hold</button>
-                        <button type="button" id="conviction-buy" disabled>Buy more</button>
-                    </div>
-                    <div class="simulator-log" id="conviction-log"></div>
-                </div>
-            </div>
-
-            <div class="calculator-card million-calculator">
-                <h2>What if Bitcoin hits $1,000,000?</h2>
-                <p><small>Enter how much Bitcoin you have in dollars today at the current price to see what it will be worth when it hits $1,000,000.</small></p>
-                <div>
-                    <label for="invest-million">Amount in USD:</label>
-                    <input type="text" id="invest-million" placeholder="e.g. 1,000">
-                </div>
-                <button id="calc-million-btn">Calculate</button>
-                <p id="result-million"></p>
-            </div>
-
-
-            <div class="calculator-card wealth-race-calculator">
+        <section class="wealth-race-calculator" aria-labelledby="wealth-race-title">
+            <div class="wealth-hero-copy">
                 <div class="calculator-kicker">Inflation-adjusted comparison</div>
-                <h2>The $10,000 Wealth Race</h2>
-                <p><small>Compare a bank savings account, Treasury bonds, the S&amp;P 500, and Bitcoin against a default 7% inflation hurdle.</small></p>
-                <div class="wealth-input-grid">
-                    <div>
-                        <label for="wealth-amount">Starting amount (USD):</label>
-                        <input type="text" id="wealth-amount" value="10,000" placeholder="e.g. 10,000">
+                <h2 id="wealth-race-title">The $10,000 Wealth Race</h2>
+                <p>Compare how the same starting dollars can behave in cash, bonds, stocks, and Bitcoin after inflation. Adjust the assumptions, then watch nominal value, real purchasing power, and the inflation hurdle update instantly.</p>
+            </div>
+
+            <div class="wealth-dashboard">
+                <form class="wealth-controls" aria-label="Wealth race assumptions">
+                    <div class="control-card featured-control">
+                        <label for="wealth-amount">Starting amount</label>
+                        <div class="money-input-wrap">
+                            <span>$</span>
+                            <input type="text" id="wealth-amount" value="10,000" inputmode="decimal" placeholder="10,000">
+                        </div>
                     </div>
-                    <div>
-                        <label for="wealth-years">Years invested:</label>
+                    <div class="control-card">
+                        <label for="wealth-years">Time horizon</label>
                         <input type="range" id="wealth-years" min="1" max="40" value="10">
                         <span class="range-readout" id="wealth-years-display">10 years</span>
                     </div>
-                    <div>
-                        <label for="inflation-rate">Inflation rate:</label>
+                    <div class="control-card">
+                        <label for="inflation-rate">Inflation rate</label>
                         <input type="range" id="inflation-rate" min="0" max="15" step="0.5" value="7">
                         <span class="range-readout" id="inflation-rate-display">7%</span>
                     </div>
-                    <div>
-                        <label for="bitcoin-rate">Bitcoin annual return:</label>
+                    <div class="control-card">
+                        <label for="bitcoin-rate">Bitcoin annual return</label>
                         <input type="range" id="bitcoin-rate" min="0" max="60" step="1" value="24">
                         <span class="range-readout" id="bitcoin-rate-display">24%</span>
                     </div>
-                </div>
+                </form>
+
                 <div class="wealth-summary" id="wealth-summary" aria-live="polite"></div>
-                <canvas id="wealth-race-chart" aria-label="Investment comparison chart"></canvas>
+
+                <div class="chart-shell">
+                    <div class="chart-header">
+                        <div>
+                            <p class="chart-eyebrow">Nominal growth path</p>
+                            <h3>Portfolio value over time</h3>
+                        </div>
+                        <p id="wealth-chart-note">Hover the chart to inspect each year.</p>
+                    </div>
+                    <canvas id="wealth-race-chart" aria-label="Investment comparison chart"></canvas>
+                </div>
+
                 <div class="wealth-table-wrap">
                     <table class="wealth-table">
                         <thead>
@@ -162,35 +126,18 @@
                                 <th>Option</th>
                                 <th>Annual return</th>
                                 <th>Nominal value</th>
-                                <th>Inflation-adjusted</th>
+                                <th>Real value</th>
+                                <th>Real gain/loss</th>
                             </tr>
                         </thead>
                         <tbody id="wealth-table-body"></tbody>
                     </table>
                 </div>
-                <p class="calculator-note">This educational model uses fixed annualized assumptions, not guaranteed future returns.</p>
+
+                <div class="wealth-insight" id="wealth-insight"></div>
+                <p class="calculator-note">This educational model uses fixed annualized assumptions, not guaranteed future returns. Bitcoin is volatile and can lose value over any time period.</p>
             </div>
-            <div class="calculator-card growth-calculator">
-                <h2>Compounded annual growth projection</h2>
-                <div>
-                    <label for="cagr-amount">Amount in USD you have today:</label>
-                    <input type="text" id="cagr-amount" placeholder="e.g. 5,000">
-                </div>
-                <div>
-                    <label for="cagr-rate">Projected annual growth rate:</label>
-                    <input type="range" id="cagr-rate" min="0" max="100" value="10">
-                    <span id="cagr-rate-display">10%</span>
-                </div>
-                <div>
-                    <button type="button" id="growth-bear">Bear Case (16%)</button>
-                    <button type="button" id="growth-base">Base Case (24%)</button>
-                    <button type="button" id="growth-bull">Bull Case (30%)</button>
-                </div>
-                <button id="cagr-calc-btn">Show Projection</button>
-                <p id="cagr-result"></p>
-                <canvas id="cagr-chart"></canvas>
-            </div>
-        </div>
+        </section>
     </main>
     <script src="js/main.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
### Motivation
- Consolidate the tools page to a single, polished wealth comparison so users can focus on the $10,000 wealth-race scenario instead of several small calculators.
- Improve the visual quality and usability of the wealth-race chart so the comparison feels professional and communicates real vs. nominal outcomes clearly.

### Description
- Replaced the multi-calculator grid with a single expanded wealth race experience and updated the page hero copy in `whatif.html`.
- Completely simplified and refactored `js/roi.js` to remove the other calculators and implement a focused wealth-race model with new helpers (`formatSignedDollars`), an insight panel, and improved summary metrics (inflation hurdle, leader, signed real gain/loss).
- Upgraded Chart.js dataset and options to produce a higher-fidelity chart (leader highlight, Bitcoin area fill, hover/tooltip styling, legend placement, interaction mode, responsive sizing) in `js/roi.js`.
- Redesigned the calculator UI in `css/style.css` with a premium dark/orange palette, larger chart shell, control cards, responsive layout, and refined table/summary styling.

### Testing
- `node --check js/roi.js` succeeded and reported no syntax errors.
- HTML validity check via a small Python HTML parse completed successfully and CSS brace balance matched (`{` == `}`).
- Served the page locally and retrieved it with `curl -sSf http://127.0.0.1:4173/whatif.html` which returned HTTP `200` and saved the file.
- Ran `git diff --check` (no issues reported) as part of local validations.
- Attempted screenshot/testing tooling with `npx --yes playwright --version` but it failed due to npm registry returning `403 Forbidden` in this environment, so automated visual regression screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540ea3300883268310929ee7efc832)