### PR TITLE
Optimize wealth calculator for mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2946,6 +2946,8 @@ body:has(.app-page) {
 .wealth-race-calculator {
     position: relative;
     overflow: hidden;
+    width: 100%;
+    min-width: 0;
     max-width: 1180px;
     margin: 0 auto 3rem;
     padding: clamp(1.25rem, 3vw, 2rem);
@@ -3013,6 +3015,7 @@ body:has(.app-page) {
 
 .wealth-dashboard {
     margin-top: 1.5rem;
+    min-width: 0;
 }
 
 .wealth-controls {
@@ -3105,6 +3108,7 @@ body:has(.app-page) {
 
 .chart-shell {
     margin-top: 1rem;
+    min-width: 0;
     padding: clamp(1rem, 2.5vw, 1.35rem);
     border: 1px solid rgba(255, 255, 255, 0.11);
     border-radius: 24px;
@@ -3113,6 +3117,7 @@ body:has(.app-page) {
 
 .chart-header {
     display: flex;
+    min-width: 0;
     justify-content: space-between;
     gap: 1rem;
     align-items: start;
@@ -3143,7 +3148,7 @@ body:has(.app-page) {
 
 .wealth-table-wrap {
     margin-top: 1rem;
-    overflow-x: auto;
+    overflow-x: hidden;
     border: 1px solid rgba(255, 255, 255, 0.10);
     border-radius: 18px;
     background: rgba(255, 255, 255, 0.045);
@@ -3220,11 +3225,146 @@ body:has(.app-page) {
 }
 
 @media (max-width: 720px) {
+    .app-page.calculators {
+        width: 100%;
+        padding-inline: max(0.75rem, env(safe-area-inset-left));
+        overflow-x: clip;
+    }
+
+    .app-page.calculators .page-hero > * {
+        max-width: 100%;
+    }
+
+    .wealth-race-calculator {
+        padding: 1rem;
+        border-radius: 22px;
+    }
+
+    .wealth-race-calculator::before {
+        inset: -8rem -12rem auto auto;
+        width: 20rem;
+        height: 20rem;
+    }
+
+    .wealth-hero-copy h2 {
+        font-size: clamp(2rem, 13vw, 3.15rem);
+        letter-spacing: -0.052em;
+    }
+
+    .wealth-controls,
+    .wealth-summary {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .control-card,
+    .wealth-summary div,
+    .chart-shell,
+    .wealth-insight {
+        border-radius: 16px;
+    }
+
     .chart-header {
         display: block;
     }
 
     #wealth-chart-note {
         margin-top: 0.4rem;
+    }
+
+    #wealth-race-chart {
+        height: 320px !important;
+    }
+
+    .wealth-table-wrap {
+        border: 0;
+        background: transparent;
+    }
+
+    .wealth-table,
+    .wealth-table thead,
+    .wealth-table tbody,
+    .wealth-table tr,
+    .wealth-table td {
+        display: block;
+        width: 100%;
+        min-width: 0;
+    }
+
+    .wealth-table {
+        border-collapse: separate;
+        border-spacing: 0 0.72rem;
+        font-size: 0.9rem;
+    }
+
+    .wealth-table thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+    }
+
+    .wealth-table tr {
+        padding: 0.8rem;
+        border: 1px solid rgba(255, 255, 255, 0.10);
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.055);
+    }
+
+    .wealth-table td {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.52rem 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.075);
+        text-align: right;
+    }
+
+    .wealth-table td::before {
+        content: attr(data-label);
+        flex: 0 0 auto;
+        color: rgba(231, 223, 210, 0.66);
+        font-size: 0.7rem;
+        font-weight: 800;
+        letter-spacing: 0.06em;
+        text-align: left;
+        text-transform: uppercase;
+    }
+
+    .wealth-table td:first-child {
+        justify-content: flex-start;
+        color: #fff;
+        font-size: 1rem;
+        font-weight: 900;
+        text-align: left;
+    }
+
+    .wealth-table td:first-child::before {
+        content: none;
+    }
+
+    .wealth-table tr:last-child td,
+    .wealth-table td:last-child {
+        border-bottom: 0;
+    }
+}
+
+@media (max-width: 390px) {
+    .app-page.calculators {
+        padding-inline: 0.6rem;
+    }
+
+    .wealth-race-calculator {
+        padding: 0.85rem;
+    }
+
+    .chart-shell {
+        padding: 0.85rem;
+    }
+
+    #wealth-race-chart {
+        height: 290px !important;
     }
 }

--- a/js/roi.js
+++ b/js/roi.js
@@ -89,11 +89,11 @@ function renderWealthRace() {
         const deltaClass = realDelta >= 0 ? 'positive' : 'negative';
         return `
             <tr>
-                <td><span class="wealth-dot" style="--dot-color: ${row.color}"></span>${row.label}</td>
-                <td>${formatPercent(row.rate)}</td>
-                <td>${formatDollars(row.nominal)}</td>
-                <td>${formatDollars(row.real)}</td>
-                <td class="${deltaClass}">${formatSignedDollars(realDelta)}</td>
+                <td data-label="Option"><span class="wealth-dot" style="--dot-color: ${row.color}"></span>${row.label}</td>
+                <td data-label="Annual return">${formatPercent(row.rate)}</td>
+                <td data-label="Nominal value">${formatDollars(row.nominal)}</td>
+                <td data-label="Real value">${formatDollars(row.real)}</td>
+                <td data-label="Real gain/loss" class="${deltaClass}">${formatSignedDollars(realDelta)}</td>
             </tr>
         `;
     }).join('');
@@ -148,8 +148,9 @@ function renderWealthRace() {
                         color: '#f5f1e8',
                         usePointStyle: true,
                         pointStyle: 'circle',
-                        padding: 18,
-                        font: { family: 'Inter', weight: '700' }
+                        boxWidth: isCompactWealthViewport() ? 8 : 12,
+                        padding: isCompactWealthViewport() ? 10 : 18,
+                        font: { family: 'Inter', weight: '700', size: isCompactWealthViewport() ? 10 : 12 }
                     }
                 },
                 tooltip: {
@@ -167,13 +168,13 @@ function renderWealthRace() {
             },
             scales: {
                 x: {
-                    title: { display: true, text: 'Years', color: '#e7dfd2', font: { weight: '800' } },
-                    ticks: { color: '#cbd5e1', maxRotation: 0 },
+                    title: { display: !isCompactWealthViewport(), text: 'Years', color: '#e7dfd2', font: { weight: '800' } },
+                    ticks: { color: '#cbd5e1', maxRotation: 0, maxTicksLimit: isCompactWealthViewport() ? 6 : 11 },
                     grid: { color: 'rgba(255,255,255,0.06)' }
                 },
                 y: {
                     beginAtZero: true,
-                    ticks: { color: '#cbd5e1', callback: value => formatDollars(value) },
+                    ticks: { color: '#cbd5e1', maxTicksLimit: isCompactWealthViewport() ? 5 : 8, callback: value => formatDollars(value) },
                     grid: { color: 'rgba(255,255,255,0.08)' }
                 }
             }
@@ -183,6 +184,10 @@ function renderWealthRace() {
 
 function yearPointRadius(years) {
     return years > 18 ? 0 : 3;
+}
+
+function isCompactWealthViewport() {
+    return window.matchMedia('(max-width: 720px)').matches;
 }
 
 ['wealth-amount', 'wealth-years', 'inflation-rate', 'bitcoin-rate'].forEach(id => {


### PR DESCRIPTION
### Motivation
- Ensure the wealth calculator fits narrow viewports without horizontal scrolling and looks high-quality on phones.
- Present the results table as readable stacked cards on small screens instead of forcing sideways scroll.
- Improve chart density and legend/tick sizing for compact displays so the visualization remains legible on mobile.

### Description
- Added layout safety rules to `css/style.css` (`width: 100%`, `min-width: 0`, `overflow-x` changes and compact paddings) to prevent horizontal overflow and allow components to shrink correctly.
- Introduced mobile-specific media rules in `css/style.css` to convert controls and summary to a single column, reduce chart height, tighten padding, and restyle the results table as stacked cards.
- Updated `js/roi.js` to emit `data-label` attributes for each table cell so mobile stacked rows show inline field labels, and added `isCompactWealthViewport()` to let Chart.js configuration adapt to small screens.
- Tuned Chart.js options in `js/roi.js` (legend `boxWidth`/`padding`/`font` and axis `maxTicksLimit`) to reduce visual clutter on compact viewports.

### Testing
- Ran `node --check js/roi.js` and it completed successfully. 
- Ran a Python script to verify CSS brace balance and it passed. 
- Ran `git diff --check` (style/syntax checks) and it reported no issues. 
- Attempted to install browser tooling for screenshot testing with Playwright, but the install failed due to a `403 Forbidden` response from the npm registry, so automated visual screenshot tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54105d9468832681e808a1eb307c9d)